### PR TITLE
pkg/apis/cincinnati/v1alpha1/cincinnati_types: "API" -> "service"

### DIFF
--- a/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
+++ b/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
@@ -14,7 +14,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: Cincinnati is the Schema for the cincinnatis API
+      description: Cincinnati is the Schema for a Cincinnati service.
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
@@ -53,7 +53,7 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Cincinnati is the Schema for the cincinnatis API
+// Cincinnati is the Schema for a Cincinnati service.
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=cincinnatis,scope=Namespaced
 type Cincinnati struct {


### PR DESCRIPTION
The Cincinnati API sound a lot like [Cincinnati's graph API][1].  Use "service" instead (which will hopefully not be confused with narrow Kubernetes Services).

[1]: https://github.com/openshift/cincinnati/blob/c1e2b4eb6ae13f093875ae7de45acaa74937c848/docs/design/cincinnati.md#graph-api