### PR TITLE
WIP: graph data init container

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: cincinnati-operator
           # TODO Replace this with the built image name
-          image: docker.io/mhrivnak/cincinnati-operator:latest
+          image: quay.io/rwsu/cincinnati-operator:latest
           command:
           - cincinnati-operator
           imagePullPolicy: Always

--- a/pkg/controller/cincinnati/names.go
+++ b/pkg/controller/cincinnati/names.go
@@ -9,6 +9,8 @@ const (
 	NameContainerGraphBuilder string = "graph-builder"
 	// NameContainerPolicyEngine is the Name property of the policy engine container
 	NameContainerPolicyEngine string = "policy-engine"
+	// NameContainerPolicyEngine is the Name property of the policy engine container
+	NameInitContainerGraphData string = "graph-data-init-container"
 )
 
 func nameDeployment(instance *cv1alpha1.Cincinnati) string {


### PR DESCRIPTION
This a draft version, that I'm submitting for feedback.

I think we will need to provide an option to include "github-secondary-metadata-scrape" in graphBuilderTOML, so that a user can choose to either use a github repo or an init container as the source of the graph data.

The init container's image needs to be parameterized.



