### PR TITLE
Option to load graph data from an init container

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ operator-sdk run --local
 ## Using an init container to load graph data
 
 The Cincinnati graph data can also be loaded from an init container.
-[docs/graph-data-init-container.md][(docs/graph-data-init-container.md) 
+[docs/graph-data-init-container.md](docs/graph-data-init-container.md) 
 details how.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,4 @@ operator-sdk run --local
 
 ## Using an init container to load graph data
 
-The Cincinnati graph data can also be loaded from an init container.
-[docs/graph-data-init-container.md](docs/graph-data-init-container.md) 
-details how.
+The Cincinnati graph data can also be [loaded from an init container](docs/graph-data-init-container.md).

--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ To run locally, you must set the operand image as shown below.
 export OPERAND_IMAGE="quay.io/app-sre/cincinnati:2873c6b" 
 operator-sdk run --local
 ```
+
+## Using an init container to load graph data
+
+The Cincinnati graph data can also be loaded from an init container.
+[docs/graph-data-init-container.md][(docs/graph-data-init-container.md) 
+details how.

--- a/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
+++ b/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
@@ -43,6 +43,12 @@ spec:
               description: GitHubRepo is the repository to use on GitHub for retrieving
                 additional graph data.
               type: string
+            graphDataImage:
+              description: GraphDataImage is an init container image that contains the
+                Cincinnati graph data and copies it to /tmp/cincinnati/graph-data. If 
+                specified, it takes precedence over GitHubOrg and GitHubRepo and disables
+                retrieval of graph data from GitHub.
+              type: string
             registry:
               description: Registry is the container registry to use, such as "quay.io".
               type: string
@@ -58,9 +64,6 @@ spec:
                 as "openshift-release-dev/ocp-release"
               type: string
           required:
-          - branch
-          - gitHubOrg
-          - gitHubRepo
           - registry
           - replicas
           - repository

--- a/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
+++ b/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
@@ -45,7 +45,7 @@ spec:
               type: string
             graphDataImage:
               description: GraphDataImage is an init container image that contains the
-                Cincinnati graph data and copies it to /tmp/cincinnati/graph-data. If 
+                Cincinnati graph data and copies it to /var/cincinnati/graph-data. If 
                 specified, it takes precedence over GitHubOrg and GitHubRepo and disables
                 retrieval of graph data from GitHub.
               type: string

--- a/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
+++ b/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
@@ -44,10 +44,10 @@ spec:
                 additional graph data.
               type: string
             graphDataImage:
-              description: GraphDataImage is an init container image that contains the
-                Cincinnati graph data and copies it to /var/cincinnati/graph-data. If 
-                specified, it takes precedence over GitHubOrg and GitHubRepo and disables
-                retrieval of graph data from GitHub.
+              description: GraphDataImage is an init container image that contains
+                the Cincinnati graph data and copies it to /var/cincinnati/graph-data.
+                If specified, it takes precedence over GitHubOrg and GitHubRepo and
+                disables retrieval of graph data from GitHub.
               type: string
             registry:
               description: Registry is the container registry to use, such as "quay.io".
@@ -72,7 +72,7 @@ spec:
           description: CincinnatiStatus defines the observed state of Cincinnati
           properties:
             conditions:
-              description: Conditions describes the state of the Cincinnati resource.
+              description: Conditions describe the state of the Cincinnati resource.
               items:
                 description: Condition represents the state of the operator's reconciliation
                   functionality.

--- a/deploy/crds/cincinnati.openshift.io_v1alpha1_cincinnati_cr.yaml
+++ b/deploy/crds/cincinnati.openshift.io_v1alpha1_cincinnati_cr.yaml
@@ -15,4 +15,4 @@ spec:
   # The second is through an init container specified by graphDataImage.
   # When specified, graphDataImage takes precedence over gitHubOrg, 
   # gitHubRepo, and branch. 
-  graphDataImage: "quay.io/rwsu/cincinnati-graph-data-container:latest"
+  #graphDataImage: "your-registry/your-repo/your-init-container"

--- a/deploy/crds/cincinnati.openshift.io_v1alpha1_cincinnati_cr.yaml
+++ b/deploy/crds/cincinnati.openshift.io_v1alpha1_cincinnati_cr.yaml
@@ -6,6 +6,13 @@ spec:
   replicas: 1
   registry: "quay.io"
   repository: "openshift-release-dev/ocp-release"
+  # There two ways to specify the source of the Cincinnati graph data.
+  # The first is through a github repository specified by these three
+  # parameters.
   gitHubOrg: "openshift"
   gitHubRepo: "cincinnati-graph-data"
   branch: "master"
+  # The second is through an init container specified by graphDataImage.
+  # When specified, graphDataImage takes precedence over gitHubOrg, 
+  # gitHubRepo, and branch. 
+  graphDataImage: "quay.io/rwsu/cincinnati-graph-data-container:latest"

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,6 @@
+FROM registry.access.redhat.com/ubi8/ubi:8.1
+
+RUN dnf install -y git
+RUN git clone https://github.com/openshift/cincinnati-graph-data
+
+CMD exec /bin/bash -c "cp -rf /cincinnati-graph-data/* /var/cincinnati/graph-data/"

--- a/docs/graph-data-init-container.md
+++ b/docs/graph-data-init-container.md
@@ -1,0 +1,48 @@
+# Graph Data Init Container
+
+Normally, the graph data is fetched directly from the Cincinnati graph
+data repository at: http://github.com/openshift/cincinnati-graph-data.
+In environments where an internet connection is not available, loading
+from an init container is another way to make the graph data available
+to Cincinnati.
+
+The role of the init container is to provide a copy of the graph data.
+During pod initialization, the init container copies the data to a volume
+at /var/cincinnati/graph-data. The graph builder is configured to read 
+the graph data from the same location.
+
+## Build the graph data init container
+
+An example of how to build an init container can be found in ./dev/Dockerfile.
+In the example, the image clones the Cincinnati graph data repository,
+http://github.com/openshift/cincinnati-graph-data.
+
+````
+podman build -f ./dev/Dockerfile -t quay.io/rwsu/cincinnati-graph-data-
+container:latest
+podman push quay.io/rwsu/cincinnati-graph-data-container:latest
+````
+
+## Configure the operator to use the init container
+
+Edit the Cincinnati CR to include a new parameter graphDataImage.
+The value should be set to the location of your init container image.
+
+For the example above:
+```
+apiVersion: cincinnati.openshift.io/v1alpha1
+kind: Cincinnati
+metadata:
+  name: example-cincinnati
+spec:
+  replicas: 1
+  registry: "quay.io"
+  repository: "openshift-release-dev/ocp-release"
+  graphDataImage: "quay.io/rwsu/cincinnati-graph-data-container:latest"
+```
+
+The gitHubOrg, gitHubRepo, and branch parameters in the CR are used
+to configure the graph builder to fetch the graph data from a
+git repository. If those parameters and graphDataImage are both specified,
+graphDataImage will take precedence. The init container will be used in
+lieu of fetching the data from git.

--- a/docs/graph-data-init-container.md
+++ b/docs/graph-data-init-container.md
@@ -1,7 +1,7 @@
 # Graph Data Init Container
 
 Normally, the graph data is fetched directly from the Cincinnati graph
-data repository at: http://github.com/openshift/cincinnati-graph-data.
+data repository at: [https://github.com/openshift/cincinnati-graph-data](https://github.com/openshift/cincinnati-graph-data).
 In environments where an internet connection is not available, loading
 from an init container is another way to make the graph data available
 to Cincinnati.
@@ -14,8 +14,7 @@ the graph data from the same location.
 ## Build the graph data init container
 
 An example of how to build an init container can be found in ./dev/Dockerfile.
-In the example, the image clones the Cincinnati graph data repository,
-http://github.com/openshift/cincinnati-graph-data.
+In the example, the image clones the Cincinnati graph data repository.
 
 ````
 podman build -f ./dev/Dockerfile -t quay.io/rwsu/cincinnati-graph-data-

--- a/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
@@ -24,19 +24,21 @@ type CincinnatiSpec struct {
 
 	// GitHubOrg is the organization to use on GitHub for retrieving additional
 	// graph data.
-	GitHubOrg string `json:"gitHubOrg"`
+	GitHubOrg string `json:"gitHubOrg,omitempty"`
 
 	// GitHubRepo is the repository to use on GitHub for retrieving additional
 	// graph data.
-	GitHubRepo string `json:"gitHubRepo"`
+	GitHubRepo string `json:"gitHubRepo,omitempty"`
 
 	// Branch is the git branch to use on GitHub for retrieving additional graph
 	// data.
-	Branch string `json:"branch"`
+	Branch string `json:"branch,omitempty"`
 
-	// GraphDataImage is an init container image that contains the Cincinnati
-	// graph data and copies it to /var/cincinnati/graph-data.
-	GraphDataImage string `json:"graphDataImage"`
+	// GraphDataImage is an init container image that contains the
+	// Cincinnati graph data and copies it to /var/cincinnati/graph-data. If
+	// specified, it takes precedence over GitHubOrg and GitHubRepo and disables
+	// retrieval of graph data from GitHub.
+	GraphDataImage string `json:"graphDataImage,omitempty"`
 }
 
 // CincinnatiStatus defines the observed state of Cincinnati

--- a/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
@@ -33,6 +33,10 @@ type CincinnatiSpec struct {
 	// Branch is the git branch to use on GitHub for retrieving additional graph
 	// data.
 	Branch string `json:"branch"`
+
+	// GraphDataImage is an init container image that contains the Cincinnati
+	// graph data and copies it to /tmp/cincinnati/graph-data.
+	GraphDataImage string `json:"graphDataImage"`
 }
 
 // CincinnatiStatus defines the observed state of Cincinnati

--- a/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
@@ -53,6 +53,11 @@ const (
 	// ConditionReconcileCompleted reports whether all required resources have been created
 	// in the cluster and reflect the specified state.
 	ConditionReconcileCompleted conditionsv1.ConditionType = "ReconcileCompleted"
+
+	// ConditionConfigurationConflict reports conflicts in the graph data configuration.
+	// There are two ways to configure the graph data source. If both ways are configured,
+	// this condition will indicate that.
+	ConditionConfigurationConflict conditionsv1.ConditionType = "ConfigurationConflict"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1alpha1/cincinnati_types.go
@@ -35,7 +35,7 @@ type CincinnatiSpec struct {
 	Branch string `json:"branch"`
 
 	// GraphDataImage is an init container image that contains the Cincinnati
-	// graph data and copies it to /tmp/cincinnati/graph-data.
+	// graph data and copies it to /var/cincinnati/graph-data.
 	GraphDataImage string `json:"graphDataImage"`
 }
 

--- a/pkg/controller/cincinnati/cincinnati_controller.go
+++ b/pkg/controller/cincinnati/cincinnati_controller.go
@@ -155,7 +155,7 @@ func (r *ReconcileCincinnati) Reconcile(request reconcile.Request) (reconcile.Re
 			Type:    cv1alpha1.ConditionConfigurationConflict,
 			Status:  corev1.ConditionTrue,
 			Reason:  "ConflictFound",
-			Message: "graphDataImage and gitHubOrg/gitHubRepo/branch should not be configured at the same time.",
+			Message: "graphDataImage and gitHubOrg/gitHubRepo/branch should not be configured at the same time. graphDataImage is winning.",
 		})
 	} else {
 		conditionsv1.SetStatusCondition(&instanceCopy.Status.Conditions, conditionsv1.Condition{

--- a/pkg/controller/cincinnati/cincinnati_controller.go
+++ b/pkg/controller/cincinnati/cincinnati_controller.go
@@ -150,6 +150,21 @@ func (r *ReconcileCincinnati) Reconcile(request reconcile.Request) (reconcile.Re
 			Message: "",
 		})
 	}
+	if instance.Spec.GraphDataImage != "" && (instance.Spec.GitHubOrg != "" || instance.Spec.GitHubRepo != "" || instance.Spec.Branch != "") {
+		conditionsv1.SetStatusCondition(&instanceCopy.Status.Conditions, conditionsv1.Condition{
+			Type:    cv1alpha1.ConditionConfigurationConflict,
+			Status:  corev1.ConditionTrue,
+			Reason:  "ConflictFound",
+			Message: "graphDataImage and gitHubOrg/gitHubRepo/branch should not be configured at the same time.",
+		})
+	} else {
+		conditionsv1.SetStatusCondition(&instanceCopy.Status.Conditions, conditionsv1.Condition{
+			Type:    cv1alpha1.ConditionConfigurationConflict,
+			Status:  corev1.ConditionFalse,
+			Reason:  "NoConflicts",
+			Message: "",
+		})
+	}
 	if err := r.client.Status().Update(ctx, instanceCopy); err != nil {
 		reqLogger.Error(err, "Failed to update Status")
 	}

--- a/pkg/controller/cincinnati/names.go
+++ b/pkg/controller/cincinnati/names.go
@@ -9,8 +9,8 @@ const (
 	NameContainerGraphBuilder string = "graph-builder"
 	// NameContainerPolicyEngine is the Name property of the policy engine container
 	NameContainerPolicyEngine string = "policy-engine"
-	// NameContainerPolicyEngine is the Name property of the policy engine container
-	NameInitContainerGraphData string = "graph-data-init-container"
+	// NameInitContainerGraphData is the Name property of the graph data container
+	NameInitContainerGraphData string = "graph-data"
 )
 
 func nameDeployment(instance *cv1alpha1.Cincinnati) string {

--- a/pkg/controller/cincinnati/names.go
+++ b/pkg/controller/cincinnati/names.go
@@ -9,6 +9,8 @@ const (
 	NameContainerGraphBuilder string = "graph-builder"
 	// NameContainerPolicyEngine is the Name property of the policy engine container
 	NameContainerPolicyEngine string = "policy-engine"
+	// NameContainerPolicyEngine is the Name property of the policy engine container
+	NameInitContainerGraphData string = "graph-data-init-container"
 )
 
 func nameDeployment(instance *cv1alpha1.Cincinnati) string {


### PR DESCRIPTION
Adds a graphDataImage property to the CRD.

The init container is created when the property is set. If unset
Cincinnati is configured to fetch the graph data from the specified
github repository.

If both graphDataImage and gitHub repository properties are set,
graphDataImage will take precedent.