### PR TITLE
Add Makefile and OWNERS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+unit-test:
+	@echo "Executing unit tests"
+	go test -v ./pkg/...

--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ approvers:
 reviewers:
 - djzager
 - mhrivnak
-- pawanpinjarkar
 - rthallisey
 - rwsu
 - sacharya

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- mhrivnak
+reviewers:
+- djzager
+- mhrivnak
+- pawanpinjarkar
+- rthallisey
+- rwsu
+- sacharya
+
+component: "Cincinnati Operator"


### PR DESCRIPTION
Makefile contains a unit-test target used by OpenShift CI.