### PR TITLE
refactor: new function to handle adding external CA

### DIFF
--- a/pkg/controller/cincinnati/cincinnati_controller.go
+++ b/pkg/controller/cincinnati/cincinnati_controller.go
@@ -239,10 +239,9 @@ func (r *ReconcileCincinnati) ensureAdditionalTrustedCA(ctx context.Context, req
 		handleErr(reqLogger, &instance.Status, "EnsureConfigMapFailed", err)
 		return err
 	}
+
 	// Mount in ConfigMap data from the cincinnati-registry key
-	externalCACert := true
-	resources.graphBuilderContainer = resources.newGraphBuilderContainer(instance, r.operandImage, externalCACert)
-	resources.deployment = resources.newDeployment(instance, externalCACert)
+	resources.addExternalCACert(instance)
 
 	return nil
 }

--- a/pkg/controller/cincinnati/cincinnati_controller_test.go
+++ b/pkg/controller/cincinnati/cincinnati_controller_test.go
@@ -230,8 +230,7 @@ func TestEnsureDeployment(t *testing.T) {
 			resources, err := newKubeResources(cincinnati, testOperandImage)
 
 			if test.caCert {
-				resources.graphBuilderContainer = resources.newGraphBuilderContainer(cincinnati, testOperandImage, test.caCert)
-				resources.deployment = resources.newDeployment(cincinnati, test.caCert)
+				resources.addExternalCACert(cincinnati)
 			}
 			err = r.ensureDeployment(context.TODO(), log, cincinnati, resources)
 			if err != nil {


### PR DESCRIPTION
Add a new function that appends the CA volume and volumemount to the
deployment and graph builder container respectively.