### PR TITLE
export GOFLAGS

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -12,6 +12,8 @@ GOBIN="${GOBIN:-$GOPATH/bin}"
 GINKGO=$GOBIN/ginkgo
 
 if ! [ -x "$GINKGO" ]; then
+	# The golang-1.13 image used in OpenShift CI enforces vendoring and go get is disabled.
+	# Workaround that by unsetting GOFLAGS.
 	export GOFLAGS=""
 	echo "Retrieving ginkgo and gomega build dependencies"
 	go get github.com/onsi/ginkgo/ginkgo

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -8,11 +8,11 @@ if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
 	echo "Openshift CI detected, deploying using image $CATALOG_FULL_IMAGE_NAME"
 fi
 
-export GOFLAGS=""
 GOBIN="${GOBIN:-$GOPATH/bin}"
 GINKGO=$GOBIN/ginkgo
 
 if ! [ -x "$GINKGO" ]; then
+	export GOFLAGS=""
 	echo "Retrieving ginkgo and gomega build dependencies"
 	go get github.com/onsi/ginkgo/ginkgo
 	go get github.com/onsi/gomega/...

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -8,6 +8,7 @@ if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
 	echo "Openshift CI detected, deploying using image $CATALOG_FULL_IMAGE_NAME"
 fi
 
+export GOFLAGS=""
 GOBIN="${GOBIN:-$GOPATH/bin}"
 GINKGO=$GOBIN/ginkgo
 


### PR DESCRIPTION
Fix go get: disabled by -mod=vendor
https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/8863/rehearse-8863-pull-ci-openshift-cincinnati-operator-release-4.5-cincinnati-operator-e2e-aws/2