### PR TITLE
Allow user to change the cert on the route outside of the CR

### DIFF
--- a/pkg/controller/cincinnati/cincinnati_controller.go
+++ b/pkg/controller/cincinnati/cincinnati_controller.go
@@ -494,10 +494,13 @@ func (r *ReconcileCincinnati) ensurePolicyEngineRoute(ctx context.Context, reqLo
 	}
 
 	// found existing resource; let's compare and update if needed
-	if !reflect.DeepEqual(found.Spec, route.Spec) {
+	if !reflect.DeepEqual(found.Spec.Port, route.Spec.Port) || !reflect.DeepEqual(found.Spec.To, route.Spec.To) {
 		reqLogger.Info("Updating Route", "Namespace", route.Namespace, "Name", route.Name)
 		updated := found.DeepCopy()
-		updated.Spec = route.Spec
+		// Update everything but updated.Spec.TLS. We want to allow user to update the TLS cert/key manually on the route
+		// and we don't want to override that change.
+		updated.Spec.Port = route.Spec.Port
+		updated.Spec.To = route.Spec.To
 		err = r.client.Update(ctx, updated)
 		if err != nil {
 			handleErr(reqLogger, &instance.Status, "UpdateRouteFailed", err)


### PR DESCRIPTION
The route is configured with a default cert from the ingress. If the customer wants to use a different TLS cert/key pair,this patch allows them to manually modify the route object with their cert/key and the controller won't override the change. If the CR or the route is deleted, the customer would have to remember to make that change again.

Alternatively, we could change our API to ask for certificate, private key and CA certificate. Other option is to ask the customer to create a new route themselves with the certificate they want. 

