### PR TITLE
Pick d6cab03 & 0d5d055b

### DIFF
--- a/deploy/olm-catalog/cincinnati-operator/0.0.1/cincinnati-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/cincinnati-operator/0.0.1/cincinnati-operator.v0.0.1.clusterserviceversion.yaml
@@ -117,6 +117,17 @@ spec:
           - list
           - watch
         - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - ""
           resources:
           - pods

--- a/pkg/controller/cincinnati/cincinnati_controller.go
+++ b/pkg/controller/cincinnati/cincinnati_controller.go
@@ -493,14 +493,19 @@ func (r *ReconcileCincinnati) ensurePolicyEngineRoute(ctx context.Context, reqLo
 		return err
 	}
 
+	updated := found.DeepCopy()
+	// Keep found tls for later use
+	tls := updated.Spec.TLS
+	// This is just so we compare the Spec on the two objects but make an exception for Spec.TLS
+	updated.Spec.TLS = route.Spec.TLS
+
 	// found existing resource; let's compare and update if needed
-	if !reflect.DeepEqual(found.Spec.Port, route.Spec.Port) || !reflect.DeepEqual(found.Spec.To, route.Spec.To) {
+	if !reflect.DeepEqual(updated.Spec, route.Spec) {
 		reqLogger.Info("Updating Route", "Namespace", route.Namespace, "Name", route.Name)
-		updated := found.DeepCopy()
-		// Update everything but updated.Spec.TLS. We want to allow user to update the TLS cert/key manually on the route
-		// and we don't want to override that change.
-		updated.Spec.Port = route.Spec.Port
-		updated.Spec.To = route.Spec.To
+		updated.Spec = route.Spec
+		// We want to allow user to update the TLS cert/key manually on the route and we don't want to override that change.
+		// Keep the existing tls on the route
+		updated.Spec.TLS = tls
 		err = r.client.Update(ctx, updated)
 		if err != nil {
 			handleErr(reqLogger, &instance.Status, "UpdateRouteFailed", err)

--- a/pkg/controller/cincinnati/cincinnati_controller.go
+++ b/pkg/controller/cincinnati/cincinnati_controller.go
@@ -494,10 +494,13 @@ func (r *ReconcileCincinnati) ensurePolicyEngineRoute(ctx context.Context, reqLo
 	}
 
 	// found existing resource; let's compare and update if needed
-	if !reflect.DeepEqual(found.Spec, route.Spec) {
+	if !reflect.DeepEqual(found.Spec.Port, route.Spec.Port) || !reflect.DeepEqual(found.Spec.To, route.Spec.To) {
 		reqLogger.Info("Updating Route", "Namespace", route.Namespace, "Name", route.Name)
 		updated := found.DeepCopy()
-		updated.Spec = route.Spec
+		// Update everything but updated.Spec.TLS. We want to allow user to update the TLS cert/key manually on the route
+		// and we don't want to override that change.
+		updated.Spec.Port = route.Spec.Port
+		updated.Spec.To = route.Spec.To
 		err = r.client.Update(ctx, updated)
 		if err != nil {
 			handleErr(reqLogger, &instance.Status, "UpdateRouteFailed", err)


### PR DESCRIPTION
Cleanup how TLS changes on the route is preserved
(cherry picked from commit 0d5d055bbdce52349229c77d0e15c39adff7a11e) 

Allow user to change the cert on the route outside of the CR
(cherry picked from commit d6cab0302e1f8e34d3b59b28ab092d4b1b83d6b9)