### PR TITLE
Added support for choosing bind address

### DIFF
--- a/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
@@ -25,13 +25,6 @@ type CincinnatiSpec struct {
 	// GraphDataImage is a container image that contains the Cincinnati graph
 	// data. The data is copied to /var/lib/cincinnati/graph-data.
 	GraphDataImage string `json:"graphDataImage"`
-
-	// IPv6 defines whether the services bind to "0.0.0.0" or to "::"
-	IPv6 bool `json:"ipv6,omitempty"`
-
-	// Address internally used for configuring the ConfigMap templates based on
-	// the IPv6 property
-	Address string
 }
 
 // CincinnatiStatus defines the observed state of Cincinnati

--- a/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
@@ -25,6 +25,9 @@ type CincinnatiSpec struct {
 	// GraphDataImage is a container image that contains the Cincinnati graph
 	// data. The data is copied to /var/lib/cincinnati/graph-data.
 	GraphDataImage string `json:"graphDataImage"`
+
+	// Address defines which address should be used when services bind to the network
+	Address string `json:"address,omitempty"`
 }
 
 // CincinnatiStatus defines the observed state of Cincinnati

--- a/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
@@ -26,8 +26,12 @@ type CincinnatiSpec struct {
 	// data. The data is copied to /var/lib/cincinnati/graph-data.
 	GraphDataImage string `json:"graphDataImage"`
 
-	// Address defines which address should be used when services bind to the network
-	Address string `json:"address,omitempty"`
+	// IPv6 defines whether the services bind to "0.0.0.0" or to "::"
+	IPv6 bool `json:"ipv6,omitempty"`
+
+	// Address internally used for configuring the ConfigMap templates based on
+	// the IPv6 property
+	Address string
 }
 
 // CincinnatiStatus defines the observed state of Cincinnati

--- a/pkg/controller/cincinnati/new.go
+++ b/pkg/controller/cincinnati/new.go
@@ -225,10 +225,11 @@ func (k *kubeResources) newPolicyEngineRoute(instance *cv1beta1.Cincinnati) *rou
 }
 
 func (k *kubeResources) newEnvConfig(instance *cv1beta1.Cincinnati) *corev1.ConfigMap {
-	// If no value is provided in the spec for the bind address
-	// we default to all IPv4 addresses
-	if instance.Spec.Address == "" {
-		instance.Spec.Address = "0.0.0.0"
+	// If IPv6 boolean property is not configured in the Spec
+	// or is set to false we default to all IPv4 addresses
+	instance.Spec.Address = "0.0.0.0"
+	if instance.Spec.IPv6 {
+		instance.Spec.Address = "::"
 	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -253,10 +254,11 @@ func (k *kubeResources) newGraphBuilderConfig(instance *cv1beta1.Cincinnati) (*c
 		return nil, err
 	}
 	builder := strings.Builder{}
-	// If no value is provided in the spec for the bind address
-	// we default to all IPv4 addresses
-	if instance.Spec.Address == "" {
-		instance.Spec.Address = "0.0.0.0"
+	// If IPv6 boolean property is not configured in the Spec
+	// or is set to false we default to all IPv4 addresses
+	instance.Spec.Address = "0.0.0.0"
+	if instance.Spec.IPv6 {
+		instance.Spec.Address = "::"
 	}
 	if err = tmpl.Execute(&builder, instance.Spec); err != nil {
 		return nil, err

--- a/pkg/controller/cincinnati/new.go
+++ b/pkg/controller/cincinnati/new.go
@@ -36,11 +36,11 @@ const graphBuilderTOML string = `verbosity = "vvv"
 
 [service]
 pause_secs = 300
-address = "{{.Address}}"
+address = "::"
 port = 8080
 
 [status]
-address = "{{.Address}}"
+address = "::"
 port = 9080
 
 [[plugin_settings]]
@@ -225,12 +225,6 @@ func (k *kubeResources) newPolicyEngineRoute(instance *cv1beta1.Cincinnati) *rou
 }
 
 func (k *kubeResources) newEnvConfig(instance *cv1beta1.Cincinnati) *corev1.ConfigMap {
-	// If IPv6 boolean property is not configured in the Spec
-	// or is set to false we default to all IPv4 addresses
-	instance.Spec.Address = "0.0.0.0"
-	if instance.Spec.IPv6 {
-		instance.Spec.Address = "::"
-	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nameEnvConfig(instance),
@@ -238,11 +232,11 @@ func (k *kubeResources) newEnvConfig(instance *cv1beta1.Cincinnati) *corev1.Conf
 		},
 		Data: map[string]string{
 			"gb.rust_backtrace":              "0",
-			"pe.address":                     instance.Spec.Address,
+			"pe.address":                     "::",
 			"pe.log.verbosity":               "vv",
 			"pe.mandatory_client_parameters": "channel",
 			"pe.rust_backtrace":              "0",
-			"pe.status.address":              instance.Spec.Address,
+			"pe.status.address":              "::",
 			"pe.upstream":                    "http://localhost:8080/v1/graph",
 		},
 	}
@@ -254,12 +248,6 @@ func (k *kubeResources) newGraphBuilderConfig(instance *cv1beta1.Cincinnati) (*c
 		return nil, err
 	}
 	builder := strings.Builder{}
-	// If IPv6 boolean property is not configured in the Spec
-	// or is set to false we default to all IPv4 addresses
-	instance.Spec.Address = "0.0.0.0"
-	if instance.Spec.IPv6 {
-		instance.Spec.Address = "::"
-	}
 	if err = tmpl.Execute(&builder, instance.Spec); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As of today, the operator will always use "0.0.0.0" as the binding address for the different services. When running on IPv6 environments that cause the services to fail since there are not IPv4 addresses available in the pod. With this change, the user will be able to choose which address is used when binding. 

By default, if no value is provided for the `address` property in the spec, we will configure "0.0.0.0", otherwise, we will configure the address configured by the user. 

Let me know what you think about the implementation, if it looks good to you I'll update the docs accordingly. 