### PR TITLE
Copy pull-secret into graphbuilder

### DIFF
--- a/pkg/controller/cincinnati/cincinnati_controller_test.go
+++ b/pkg/controller/cincinnati/cincinnati_controller_test.go
@@ -63,12 +63,15 @@ func TestMain(m *testing.M) {
 func TestReconcile(t *testing.T) {
 	tests := []struct {
 		name               string
-		cincinnati         *cv1beta1.Cincinnati
+		existingObjs       []runtime.Object
 		expectedConditions []conditionsv1.Condition
 	}{
 		{
-			name:       "Reconcile",
-			cincinnati: newDefaultCincinnati(),
+			name: "Reconcile",
+			existingObjs: []runtime.Object{
+				newDefaultCincinnati(),
+				newSecret(),
+			},
 			expectedConditions: []conditionsv1.Condition{
 				{
 					Type:   cv1beta1.ConditionReconcileCompleted,
@@ -83,9 +86,8 @@ func TestReconcile(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cincinnati := test.cincinnati
-			r := newTestReconciler(cincinnati)
-			request := newRequest(cincinnati)
+			r := newTestReconciler(test.existingObjs...)
+			request := newRequest(newDefaultCincinnati())
 
 			_, err := r.Reconcile(request)
 			if err != nil {
@@ -138,6 +140,60 @@ func TestEnsureEnvConfig(t *testing.T) {
 	assert.NotEmpty(t, found.Data["pe.upstream"])
 }
 
+func TestEnsurePullSecret(t *testing.T) {
+	tests := []struct {
+		name           string
+		existingObjs   []runtime.Object
+		expectedError  error
+		expectedSecret *corev1.Secret
+	}{
+		{
+			name: "NoSecret",
+			existingObjs: []runtime.Object{
+				newDefaultCincinnati(),
+			},
+			expectedError: fmt.Errorf("secrets \"%v\" not found", NamePullSecret),
+		},
+		{
+			name: "SecretCreate",
+			existingObjs: []runtime.Object{
+				newDefaultCincinnati(),
+				newSecret(),
+			},
+			expectedSecret: func() *corev1.Secret {
+				localSecret := newSecret()
+				localSecret.Namespace = newDefaultCincinnati().Namespace
+				return localSecret
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cincinnati := newDefaultCincinnati()
+			r := newTestReconciler(test.existingObjs...)
+
+			resources, err := newKubeResources(cincinnati, testOperandImage)
+			err = r.postAddPullSecret(context.TODO(), log, cincinnati, resources)
+			if err != nil {
+				assert.Error(t, err)
+			}
+			err = r.ensurePullSecret(context.TODO(), log, cincinnati, resources)
+
+			verifyError(t, err, test.expectedError)
+
+			found := &corev1.Secret{}
+			err = r.client.Get(context.TODO(), types.NamespacedName{Name: NamePullSecret, Namespace: cincinnati.Namespace}, found)
+			if err != nil {
+				assert.Error(t, err)
+				assert.Empty(t, found)
+			} else {
+				verifyOwnerReference(t, found.ObjectMeta.OwnerReferences[0], cincinnati)
+				assert.Equal(t, found.Data, test.expectedSecret.Data)
+			}
+		})
+	}
+}
+
 func TestEnsureAdditionalTrustedCA(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -171,7 +227,7 @@ func TestEnsureAdditionalTrustedCA(t *testing.T) {
 			expectedError: fmt.Errorf("configmaps \"%v\" not found", newImage().Spec.AdditionalTrustedCA.Name),
 		},
 		{
-			name: "ConfigMapCreate",
+			name: "NoConfigMapKey",
 			existingObjs: []runtime.Object{
 				newDefaultCincinnati(),
 				newImage(),
@@ -183,6 +239,24 @@ func TestEnsureAdditionalTrustedCA(t *testing.T) {
 				return localConfigMap
 			}(),
 		},
+		{
+			name: "ConfigMapCreate",
+			existingObjs: []runtime.Object{
+				newDefaultCincinnati(),
+				newImage(),
+				func() *corev1.ConfigMap {
+					localConfigMap := newConfigMap()
+					localConfigMap.Data[NameCertConfigMapKey] = "some random text"
+					return localConfigMap
+				}(),
+			},
+			expectedConfigMap: func() *corev1.ConfigMap {
+				localConfigMap := newConfigMap()
+				localConfigMap.Namespace = newDefaultCincinnati().Namespace
+				localConfigMap.Data[NameCertConfigMapKey] = "some random text"
+				return localConfigMap
+			}(),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -190,6 +264,10 @@ func TestEnsureAdditionalTrustedCA(t *testing.T) {
 			r := newTestReconciler(test.existingObjs...)
 
 			resources, err := newKubeResources(cincinnati, testOperandImage)
+			err = r.postAddExternalCACert(context.TODO(), log, cincinnati, resources)
+			if err != nil {
+				assert.Error(t, err)
+			}
 			err = r.ensureAdditionalTrustedCA(context.TODO(), log, cincinnati, resources)
 
 			verifyError(t, err, test.expectedError)
@@ -209,40 +287,66 @@ func TestEnsureAdditionalTrustedCA(t *testing.T) {
 
 func TestEnsureDeployment(t *testing.T) {
 	tests := []struct {
-		name       string
-		cincinnati *cv1beta1.Cincinnati
-		caCert     bool
+		name         string
+		existingObjs []runtime.Object
+		caCert       bool
 	}{
 		{
-			name:       "EnsureDeployment",
-			cincinnati: newDefaultCincinnati(),
-			caCert:     false,
-		},
-		{
-			name: "EnsureDeploymentWithGraphDataImage",
-			cincinnati: func() *cv1beta1.Cincinnati {
-				cincinnati := newDefaultCincinnati()
-				cincinnati.Spec.GraphDataImage = testGraphDataImage
-				return cincinnati
-			}(),
+			name: "EnsureDeployment",
+			existingObjs: []runtime.Object{
+				newDefaultCincinnati(),
+				newSecret(),
+			},
 			caCert: false,
 		},
 		{
-			name:       "EnsureDeploymentWithCaCert",
-			cincinnati: newDefaultCincinnati(),
-			caCert:     true,
+			name: "EnsureDeploymentWithGraphDataImage",
+			existingObjs: []runtime.Object{
+				func() *cv1beta1.Cincinnati {
+					cincinnati := newDefaultCincinnati()
+					cincinnati.Spec.GraphDataImage = testGraphDataImage
+					return cincinnati
+				}(),
+				newSecret(),
+			},
+			caCert: false,
+		},
+		{
+			name: "EnsureDeploymentWithCaCert",
+			existingObjs: []runtime.Object{
+				newDefaultCincinnati(),
+				newSecret(),
+				newImage(),
+				func() *corev1.ConfigMap {
+					localConfigMap := newConfigMap()
+					localConfigMap.Data[NameCertConfigMapKey] = "some random text"
+					return localConfigMap
+				}(),
+			},
+			caCert: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cincinnati := test.cincinnati
-			r := newTestReconciler(cincinnati)
+			cincinnati := newDefaultCincinnati()
+			r := newTestReconciler(test.existingObjs...)
 
 			resources, err := newKubeResources(cincinnati, testOperandImage)
 
-			if test.caCert {
-				resources.addExternalCACert(cincinnati)
+			err = r.postAddPullSecret(context.TODO(), log, cincinnati, resources)
+			if err != nil {
+				t.Fatal(err)
 			}
+
+			if test.caCert {
+				err = r.postAddExternalCACert(context.TODO(), log, cincinnati, resources)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			resources.regenerate(cincinnati)
+
 			err = r.ensureDeployment(context.TODO(), log, cincinnati, resources)
 			if err != nil {
 				t.Fatal(err)
@@ -265,9 +369,12 @@ func TestEnsureDeployment(t *testing.T) {
 			assert.Equal(t, found.Spec.Template.Spec.Containers[1].Image, resources.graphBuilderContainer.Image)
 			assert.Equal(t, found.Spec.Template.Spec.Containers[1].Name, resources.policyEngineContainer.Name)
 			assert.Equal(t, found.Spec.Template.Spec.Containers[1].Image, resources.graphBuilderContainer.Image)
+			assert.Equal(t, found.Spec.Template.Spec.Volumes[2].Name, NamePullSecret)
+			assert.Equal(t, found.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name, NamePullSecret)
+
 			if test.caCert {
-				assert.Equal(t, found.Spec.Template.Spec.Volumes[2].Name, NameTrustedCAVolume)
-				assert.Equal(t, found.Spec.Template.Spec.Containers[0].VolumeMounts[2].Name, NameTrustedCAVolume)
+				assert.Equal(t, found.Spec.Template.Spec.Volumes[3].Name, NameTrustedCAVolume)
+				assert.Equal(t, found.Spec.Template.Spec.Containers[0].VolumeMounts[3].Name, NameTrustedCAVolume)
 			}
 
 			initContainer := found.Spec.Template.Spec.InitContainers[0]
@@ -454,6 +561,18 @@ func newConfigMap() *corev1.ConfigMap {
 		},
 		Data: map[string]string{
 			"testData": "some random text",
+		},
+	}
+}
+
+func newSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NamePullSecret,
+			Namespace: openshiftConfigNamespace,
+		},
+		Data: map[string][]byte{
+			"testData": []byte("some random text"),
 		},
 	}
 }

--- a/pkg/controller/cincinnati/names.go
+++ b/pkg/controller/cincinnati/names.go
@@ -18,6 +18,8 @@ const (
 	NameTrustedCAVolume = "trusted-ca"
 	// NameCertConfigMapKey is the ConfigMap key name where the operator expects the external registry CA Cert
 	NameCertConfigMapKey = "cincinnati-registry"
+	// NamePullSecret is the OpenShift pull secret name
+	NamePullSecret = "pull-secret"
 )
 
 func nameDeployment(instance *cv1beta1.Cincinnati) string {

--- a/pkg/controller/cincinnati/names.go
+++ b/pkg/controller/cincinnati/names.go
@@ -18,8 +18,8 @@ const (
 	NameTrustedCAVolume = "trusted-ca"
 	// NameCertConfigMapKey is the ConfigMap key name where the operator expects the external registry CA Cert
 	NameCertConfigMapKey = "cincinnati-registry"
-	// NamePullSecret is the OpenShift pull secret name
-	NamePullSecret = "pull-secret"
+	// namePullSecret is the OpenShift pull secret name
+	namePullSecret = "pull-secret"
 )
 
 func nameDeployment(instance *cv1beta1.Cincinnati) string {
@@ -55,7 +55,7 @@ func nameAdditionalTrustedCA(instance *cv1beta1.Cincinnati) string {
 }
 
 func namePullSecretCopy(instance *cv1beta1.Cincinnati) string {
-	return instance.Name + "-" + NamePullSecret
+	return instance.Name + "-" + namePullSecret
 }
 
 // When running a single replica, allow 0 available so we don't block node

--- a/pkg/controller/cincinnati/names.go
+++ b/pkg/controller/cincinnati/names.go
@@ -54,6 +54,10 @@ func nameAdditionalTrustedCA(instance *cv1beta1.Cincinnati) string {
 	return instance.Name + "-trusted-ca"
 }
 
+func namePullSecretCopy(instance *cv1beta1.Cincinnati) string {
+	return instance.Name + "-" + NamePullSecret
+}
+
 // When running a single replica, allow 0 available so we don't block node
 // drains. Otherwise require 1.
 func getMinAvailablePBD(instance *cv1beta1.Cincinnati) intstr.IntOrString {

--- a/pkg/controller/cincinnati/new.go
+++ b/pkg/controller/cincinnati/new.go
@@ -48,7 +48,7 @@ name = "release-scrape-dockerv2"
 registry = "{{.Registry}}"
 repository = "{{.Repository}}"
 fetch_concurrency = 16
-credentials_path = "/var/lib/cincinnati/registry-credentials"
+credentials_path = "/var/lib/cincinnati/registry-credentials/.dockerconfigjson"
 
 [[plugin_settings]]
 name = "openshift-secondary-metadata-parse"
@@ -374,7 +374,7 @@ func (k *kubeResources) addPullSecret(instance *cv1beta1.Cincinnati) {
 			Name: NamePullSecret,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: NamePullSecret,
+					SecretName: namePullSecretCopy(instance),
 					DefaultMode: &mode,
 				},
 			},

--- a/pkg/controller/cincinnati/new.go
+++ b/pkg/controller/cincinnati/new.go
@@ -78,6 +78,8 @@ type kubeResources struct {
 	graphBuilderService    *corev1.Service
 	policyEngineService    *corev1.Service
 	policyEngineRoute      *routev1.Route
+	trustedCAConfig        *corev1.ConfigMap
+	pullSecret             *corev1.Secret
 }
 
 func newKubeResources(instance *cv1beta1.Cincinnati, image string) (*kubeResources, error) {
@@ -332,6 +334,26 @@ func (k *kubeResources) newDeployment(instance *cv1beta1.Cincinnati) *appsv1.Dep
 		}
 	}
 	return dep
+}
+
+func (k *kubeResources) newTrustedCAConfig(instance *cv1beta1.Cincinnati, cm *corev1.ConfigMap) {
+	k.trustedCAConfig = &corev1.ConfigMap{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      nameAdditionalTrustedCA(instance),
+                        Namespace: instance.Namespace,
+                },
+                Data: cm.Data,
+        }
+}
+
+func (k *kubeResources) newPullSecret(instance *cv1beta1.Cincinnati, s *corev1.Secret) {
+	k.pullSecret = &corev1.Secret{
+                ObjectMeta: metav1.ObjectMeta{
+                        Name:      namePullSecretCopy(instance),
+                        Namespace: instance.Namespace,
+                },
+                Data: s.Data,
+        }
 }
 
 func (k *kubeResources) addPullSecret(instance *cv1beta1.Cincinnati) {

--- a/pkg/controller/cincinnati/new.go
+++ b/pkg/controller/cincinnati/new.go
@@ -66,20 +66,22 @@ name = "edge-add-remove"`
 // once up-front makes it MUCH easier to access those resources as-needed
 // throughout the reconciliation code.
 type kubeResources struct {
-	envConfig              *corev1.ConfigMap
-	envConfigHash          string
-	graphBuilderConfig     *corev1.ConfigMap
-	graphBuilderConfigHash string
-	podDisruptionBudget    *policyv1beta1.PodDisruptionBudget
-	deployment             *appsv1.Deployment
-	graphBuilderContainer  *corev1.Container
-	graphDataInitContainer *corev1.Container
-	policyEngineContainer  *corev1.Container
-	graphBuilderService    *corev1.Service
-	policyEngineService    *corev1.Service
-	policyEngineRoute      *routev1.Route
-	trustedCAConfig        *corev1.ConfigMap
-	pullSecret             *corev1.Secret
+	envConfig                *corev1.ConfigMap
+	envConfigHash            string
+	graphBuilderConfig       *corev1.ConfigMap
+	graphBuilderConfigHash   string
+	podDisruptionBudget      *policyv1beta1.PodDisruptionBudget
+	deployment               *appsv1.Deployment
+	graphBuilderContainer    *corev1.Container
+	graphDataInitContainer   *corev1.Container
+	policyEngineContainer    *corev1.Container
+	graphBuilderService      *corev1.Service
+	policyEngineService      *corev1.Service
+	policyEngineRoute        *routev1.Route
+	trustedCAConfig          *corev1.ConfigMap
+	pullSecret               *corev1.Secret
+	volumes                  *[]corev1.Volume
+	graphBuilderVolumeMounts *[]corev1.VolumeMount
 }
 
 func newKubeResources(instance *cv1beta1.Cincinnati, image string) (*kubeResources, error) {
@@ -105,6 +107,8 @@ func newKubeResources(instance *cv1beta1.Cincinnati, image string) (*kubeResourc
 	}
 	k.envConfigHash = envConfigHash
 	k.podDisruptionBudget = k.newPodDisruptionBudget(instance)
+	k.volumes = k.newVolumes(instance)
+	k.graphBuilderVolumeMounts = k.newGraphBuilderVolumeMounts(instance)
 	k.graphBuilderContainer = k.newGraphBuilderContainer(instance, image)
 	k.graphDataInitContainer = k.newGraphDataInitContainer(instance)
 	k.policyEngineContainer = k.newPolicyEngineContainer(instance, image)
@@ -269,7 +273,6 @@ func (k *kubeResources) newDeployment(instance *cv1beta1.Cincinnati) *appsv1.Dep
 	name := nameDeployment(instance)
 	maxUnavailable := intstr.FromString("50%")
 	maxSurge := intstr.FromString("100%")
-	mode := int32(420) // 0644
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -301,25 +304,7 @@ func (k *kubeResources) newDeployment(instance *cv1beta1.Cincinnati) *appsv1.Dep
 					},
 				},
 				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						corev1.Volume{
-							Name: "configs",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									DefaultMode: &mode,
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: nameConfig(instance),
-									},
-								},
-							},
-						},
-						corev1.Volume{
-							Name: "cincinnati-graph-data",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-					},
+					Volumes: *k.volumes,
 					Containers: []corev1.Container{
 						*k.graphBuilderContainer,
 						*k.policyEngineContainer,
@@ -336,81 +321,105 @@ func (k *kubeResources) newDeployment(instance *cv1beta1.Cincinnati) *appsv1.Dep
 	return dep
 }
 
+func (k *kubeResources) newVolumes(instance *cv1beta1.Cincinnati) *[]corev1.Volume {
+	mode := int32(420) // 0644
+	return &[]corev1.Volume{
+		corev1.Volume{
+			Name: "configs",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: &mode,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: nameConfig(instance),
+					},
+				},
+			},
+		},
+		corev1.Volume{
+			Name: "cincinnati-graph-data",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+	}
+}
+
 func (k *kubeResources) newTrustedCAConfig(instance *cv1beta1.Cincinnati, cm *corev1.ConfigMap) {
 	k.trustedCAConfig = &corev1.ConfigMap{
-                ObjectMeta: metav1.ObjectMeta{
-                        Name:      nameAdditionalTrustedCA(instance),
-                        Namespace: instance.Namespace,
-                },
-                Data: cm.Data,
-        }
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nameAdditionalTrustedCA(instance),
+			Namespace: instance.Namespace,
+		},
+		Data: cm.Data,
+	}
 }
 
 func (k *kubeResources) newPullSecret(instance *cv1beta1.Cincinnati, s *corev1.Secret) {
 	k.pullSecret = &corev1.Secret{
-                ObjectMeta: metav1.ObjectMeta{
-                        Name:      namePullSecretCopy(instance),
-                        Namespace: instance.Namespace,
-                },
-                Data: s.Data,
-        }
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namePullSecretCopy(instance),
+			Namespace: instance.Namespace,
+		},
+		Data: s.Data,
+	}
+}
+
+// regenerate - rebuild smaller resources to regerate the larger object
+func (k *kubeResources) regenerate(instance *cv1beta1.Cincinnati) {
+	k.graphBuilderContainer = k.newGraphBuilderContainer(instance, k.graphBuilderContainer.Image)
+	k.deployment = k.newDeployment(instance)
 }
 
 func (k *kubeResources) addPullSecret(instance *cv1beta1.Cincinnati) {
 	mode := int32(420) // 0644
 
 	// Add the volumeMount to the graph builder container
-	k.graphBuilderContainer.VolumeMounts = append(k.graphBuilderContainer.VolumeMounts, corev1.VolumeMount{
-			Name:      NamePullSecret,
-			ReadOnly:  true,
-			MountPath: "/var/lib/cincinnati/registry-credentials",
+	*k.graphBuilderVolumeMounts = append(*k.graphBuilderVolumeMounts, corev1.VolumeMount{
+		Name:      NamePullSecret,
+		ReadOnly:  true,
+		MountPath: "/var/lib/cincinnati/registry-credentials",
 	})
-
-	// Rebuild the deployment since we modified the container definition
-	k.deployment = k.newDeployment(instance)
 
 	// Add the volume for the graph builder container
-	k.deployment.Spec.Template.Spec.Volumes = append(k.deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: NamePullSecret,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: namePullSecretCopy(instance),
-					DefaultMode: &mode,
-				},
+	*k.volumes = append(*k.volumes, corev1.Volume{
+		Name: NamePullSecret,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  namePullSecretCopy(instance),
+				DefaultMode: &mode,
 			},
+		},
 	})
+
 }
 
 func (k *kubeResources) addExternalCACert(instance *cv1beta1.Cincinnati) {
 	mode := int32(420) // 0644
 
 	// Add the volumeMount to the graph builder container
-	k.graphBuilderContainer.VolumeMounts = append(k.graphBuilderContainer.VolumeMounts, corev1.VolumeMount{
-			Name:      NameTrustedCAVolume,
-			ReadOnly:  true,
-			MountPath: "/etc/pki/ca-trust/extracted/pem",
+	*k.graphBuilderVolumeMounts = append(*k.graphBuilderVolumeMounts, corev1.VolumeMount{
+		Name:      NameTrustedCAVolume,
+		ReadOnly:  true,
+		MountPath: "/etc/pki/ca-trust/extracted/pem",
 	})
 
-	// Rebuild the deployment since we modified the container definition
-	k.deployment = k.newDeployment(instance)
-
 	// Add the volume for the graph builder container
-	k.deployment.Spec.Template.Spec.Volumes = append(k.deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: NameTrustedCAVolume,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					DefaultMode: &mode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: nameAdditionalTrustedCA(instance),
-					},
-					Items: []corev1.KeyToPath{
-						corev1.KeyToPath{
-							Path: "tls-ca-bundle.pem",
-							Key:  NameCertConfigMapKey,
-						},
+	*k.volumes = append(*k.volumes, corev1.Volume{
+		Name: NameTrustedCAVolume,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				DefaultMode: &mode,
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: nameAdditionalTrustedCA(instance),
+				},
+				Items: []corev1.KeyToPath{
+					corev1.KeyToPath{
+						Path: "tls-ca-bundle.pem",
+						Key:  NameCertConfigMapKey,
 					},
 				},
 			},
+		},
 	})
 }
 
@@ -465,17 +474,7 @@ func (k *kubeResources) newGraphBuilderContainer(instance *cv1beta1.Cincinnati, 
 				corev1.ResourceMemory: *resource.NewQuantity(64*1024*1024, resource.BinarySI),
 			},
 		},
-		VolumeMounts: []corev1.VolumeMount{
-			corev1.VolumeMount{
-				Name:      "configs",
-				ReadOnly:  true,
-				MountPath: "/etc/configs",
-			},
-			corev1.VolumeMount{
-				Name:      "cincinnati-graph-data",
-				MountPath: "/var/lib/cincinnati/graph-data",
-			},
-		},
+		VolumeMounts: *k.graphBuilderVolumeMounts,
 		LivenessProbe: &corev1.Probe{
 			FailureThreshold:    3,
 			SuccessThreshold:    1,
@@ -506,6 +505,20 @@ func (k *kubeResources) newGraphBuilderContainer(instance *cv1beta1.Cincinnati, 
 		},
 	}
 	return g
+}
+
+func (k *kubeResources) newGraphBuilderVolumeMounts(instance *cv1beta1.Cincinnati) *[]corev1.VolumeMount {
+	return &[]corev1.VolumeMount{
+		corev1.VolumeMount{
+			Name:      "configs",
+			ReadOnly:  true,
+			MountPath: "/etc/configs",
+		},
+		corev1.VolumeMount{
+			Name:      "cincinnati-graph-data",
+			MountPath: "/var/lib/cincinnati/graph-data",
+		},
+	}
 }
 
 func (k *kubeResources) newPolicyEngineContainer(instance *cv1beta1.Cincinnati, image string) *corev1.Container {


### PR DESCRIPTION
The [basic auth support](https://github.com/openshift/cincinnati/pull/292) patch in Cincinnati added a `credentials_path` to point to a docker config file with basic auth for registries.  Since it's likely the installer is using the same local registry as CIncinnati, we'll mount the `pull-secret` secret into the graph builder.  This avoids the user having to essentially create the pull-secret twice. 