### PR TITLE
pkg/apis/cincinnati/v1beta1: Explicitly require registry and repository

### DIFF
--- a/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
+++ b/deploy/crds/cincinnati.openshift.io_cincinnatis_crd.yaml
@@ -27,26 +27,28 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
+          description: 'metadata is standard object metadata.  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
           type: object
         spec:
-          description: CincinnatiSpec defines the desired state of Cincinnati
+          description: spec is the desired state of the Cincinnati service.  The operator
+            will work to ensure that the desired configuration is applied to the cluster.
           properties:
             graphDataImage:
-              description: GraphDataImage is a container image that contains the Cincinnati
-                graph data. The data is copied to /var/lib/cincinnati/graph-data.
+              description: graphDataImage is a container image that contains the Cincinnati
+                graph data.
               type: string
             registry:
-              description: Registry is the container registry to use, such as "quay.io".
+              description: registry is the container registry to use, such as "quay.io".
               type: string
             replicas:
-              description: Replicas is the number of pods to run. When >=2, a PodDisruptionBudget
+              description: replicas is the number of pods to run. When >=2, a PodDisruptionBudget
                 will ensure that voluntary disruption leaves at least one Pod running
                 at all times.
               format: int32
               minimum: 1
               type: integer
             repository:
-              description: Repository is the repository to use in the Registry, such
+              description: repository is the repository to use in the Registry, such
                 as "openshift-release-dev/ocp-release"
               type: string
           required:
@@ -56,7 +58,8 @@ spec:
           - repository
           type: object
         status:
-          description: CincinnatiStatus defines the observed state of Cincinnati
+          description: status contains information about the current state of the
+            Cincinnati service.
           properties:
             conditions:
               description: Conditions describe the state of the Cincinnati resource.
@@ -86,6 +89,9 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - metadata
+      - spec
       type: object
   version: v1beta1
   versions:

--- a/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
+++ b/pkg/apis/cincinnati/v1beta1/cincinnati_types.go
@@ -9,21 +9,25 @@ import (
 
 // CincinnatiSpec defines the desired state of Cincinnati
 type CincinnatiSpec struct {
-	// +kubebuilder:validation:Minimum=1
-	// Replicas is the number of pods to run. When >=2, a PodDisruptionBudget
+	// replicas is the number of pods to run. When >=2, a PodDisruptionBudget
 	// will ensure that voluntary disruption leaves at least one Pod running at
 	// all times.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Required
 	Replicas int32 `json:"replicas"`
 
-	// Registry is the container registry to use, such as "quay.io".
+	// registry is the container registry to use, such as "quay.io".
+	// +kubebuilder:validation:Required
 	Registry string `json:"registry"`
 
-	// Repository is the repository to use in the Registry, such as
+	// repository is the repository to use in the Registry, such as
 	// "openshift-release-dev/ocp-release"
+	// +kubebuilder:validation:Required
 	Repository string `json:"repository"`
 
-	// GraphDataImage is a container image that contains the Cincinnati graph
-	// data. The data is copied to /var/lib/cincinnati/graph-data.
+	// graphDataImage is a container image that contains the Cincinnati graph
+	// data.
+	// +kubebuilder:validation:Required
 	GraphDataImage string `json:"graphDataImage"`
 }
 
@@ -32,7 +36,7 @@ type CincinnatiStatus struct {
 	// Conditions describe the state of the Cincinnati resource.
 	// +patchMergeKey=type
 	// +patchStrategy=merge
-	// +optional
+	// +kubebuilder:validation:Optional
 	Conditions []conditionsv1.Condition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 }
 
@@ -53,10 +57,21 @@ const (
 // +kubebuilder:resource:path=cincinnatis,scope=Namespaced
 type Cincinnati struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CincinnatiSpec   `json:"spec,omitempty"`
-	Status CincinnatiStatus `json:"status,omitempty"`
+	// metadata is standard object metadata.  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+	// +kubebuilder:validation:Required
+	metav1.ObjectMeta `json:"metadata"`
+
+	// spec is the desired state of the Cincinnati service.  The
+	// operator will work to ensure that the desired configuration is
+	// applied to the cluster.
+	// +kubebuilder:validation:Required
+	Spec   CincinnatiSpec   `json:"spec"`
+
+	// status contains information about the current state of the
+	// Cincinnati service.
+	// +kubebuilder:validation:Optional
+	Status CincinnatiStatus `json:"status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Users must point the update service at a repository so the graph builder can scrape for primary release metadata.

Also require the `spec`, but leave `status` optional.  This allows users to upload a manifest, while leaving the status empty for the controller to fill in later.

WIP because I need to figure out how to regenerate the machine-written portions of this package.