### PR TITLE
pkg/apis/cincinnati/v1beta1: Drop redundant doc.go

### DIFF
--- a/pkg/apis/cincinnati/v1beta1/doc.go
+++ b/pkg/apis/cincinnati/v1beta1/doc.go
@@ -1,4 +1,0 @@
-// Package v1beta1 contains API Schema definitions for the cincinnati v1beta1 API group
-// +k8s:deepcopy-gen=package,register
-// +groupName=cincinnati.openshift.io
-package v1beta1

--- a/pkg/apis/cincinnati/v1beta1/register.go
+++ b/pkg/apis/cincinnati/v1beta1/register.go
@@ -1,6 +1,4 @@
-// NOTE: Boilerplate only.  Ignore this file.
-
-// Package v1beta1 contains API Schema definitions for the cincinnati v1beta1 API group
+// Package v1beta1 contains API Schema definitions for the Cincinnati v1beta1 API group.
 // +k8s:deepcopy-gen=package,register
 // +groupName=cincinnati.openshift.io
 package v1beta1


### PR DESCRIPTION
We've had a package docstring in both doc.go and register.go since v1alpha1 in 52a976598c (#1).  But there's no reason to have a `doc.go` declaration when `register.go` already defines the same material.

Also add a trailing period to the docstring sentence and remove the boilerplate comment, because this is a hand-maintained file, even if changes will be rare.