### PR TITLE
README: Document operator-sdk installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # cincinnati-operator
 
+This operator is developed using the [operator SDK][operator-sdk], version 0.16.
+Installation docs are [here][operator-sdk-installation].
+
 ## Run locally
 
 To run locally, you must set the operand image as shown below.
@@ -44,3 +47,6 @@ export GRAPH_DATA_IMAGE="your-registry/your-repo/your-init-container:tag"
 ```
 make unit-test
 ```
+
+[operator-sdk]: https://sdk.operatorframework.io/docs/
+[operator-sdk-installation]: https://sdk.operatorframework.io/docs/install-operator-sdk/


### PR DESCRIPTION
So new folks understand where the `operator-sdk` command should come from, or remember to look in `vendor/` to see which version to use:

```console
$ grep '#.*operator-sdk' vendor/modules.txt 
```