### PR TITLE
pkg/controller/cincinnati: Use InsecureEdgeTerminationPolicyNone

### DIFF
--- a/docs/disconnected-cincinnati-operator.md
+++ b/docs/disconnected-cincinnati-operator.md
@@ -237,7 +237,7 @@ You might want to review the documentation around disconnected registries to lea
 3. Check the cincinnati service
 
     ~~~sh
-    curl --header 'Accept:application/json' http://$(oc -n "${NAMESPACE}" get route example-name-policy-engine-route -o jsonpath='{.spec.host}')/api/upgrades_info/v1/graph\?channel=stable-4.5 | jq
+    curl --header 'Accept:application/json' https://$(oc -n "${NAMESPACE}" get route example-name-policy-engine-route -o jsonpath='{.spec.host}')/api/upgrades_info/v1/graph\?channel=stable-4.5 | jq
     ~~~
 
     > **OUTPUT**
@@ -281,7 +281,7 @@ You might want to review the documentation around disconnected registries to lea
 5. Patch the ClusterVersion to use our Cincinnati instance rather than the public one
 
     ~~~sh
-    CINCINNATI_ROUTE=$(oc -n "${NAMESPACE}" get route example-name-policy-engine-route -o jsonpath=http://'{.spec.host}'/api/upgrades_info/v1/graph)
+    CINCINNATI_ROUTE=$(oc -n "${NAMESPACE}" get route example-name-policy-engine-route -o jsonpath=https://'{.spec.host}'/api/upgrades_info/v1/graph)
     PATCH="{\"spec\":{\"upstream\":\"${CINCINNATI_ROUTE}\"}}"
     oc patch clusterversion version -p $PATCH --type merge
     ~~~
@@ -313,7 +313,7 @@ You can print the graph for a specific channel in your Cincinnati instance using
 sudo dnf install -y graphviz
 curl -O https://raw.githubusercontent.com/openshift/cincinnati/master/hack/graph.sh
 chmod +x graph.sh
-curl --header 'Accept:application/json' "http://example-name-policy-engine-${NAMESPACE}.apps.mgmt-hub.e2e.bos.redhat.com/api/upgrades_info/v1/graph?channel=stable-4.5" | ./graph.sh | dot -Tpng > graph.png
+curl --header 'Accept:application/json' "https://example-name-policy-engine-${NAMESPACE}.apps.mgmt-hub.e2e.bos.redhat.com/api/upgrades_info/v1/graph?channel=stable-4.5" | ./graph.sh | dot -Tpng > graph.png
 ~~~
 
 ## Mirror the release images

--- a/docs/disconnected-cincinnati-operator.md
+++ b/docs/disconnected-cincinnati-operator.md
@@ -120,7 +120,7 @@ You can follow [this doc](https://docs.openshift.com/container-platform/4.5/oper
 11. Deploy the Cincinnati Operator
 
     ~~~sh
-    NAMESPACE=cincinnati-operator
+    NAMESPACE=example-namespace
     oc create ns $NAMESPACE
     cat <<EOF | oc -n $NAMESPACE create -f - 
     apiVersion: operators.coreos.com/v1alpha1
@@ -207,11 +207,11 @@ You might want to review the documentation around disconnected registries to lea
     * Option 1: OpenShift Release Image and Release Content in different paths (release under ocp4/release, content under ocp4)
 
         ~~~sh
-        cat <<EOF | oc -n cincinnati-operator create -f -
+        cat <<EOF | oc -n "${NAMESPACE}" create -f -
         apiVersion: cincinnati.openshift.io/v1beta1
         kind: Cincinnati
         metadata:
-          name: disconnected-cincinnati
+          name: example-name
         spec:
           replicas: 1
           registry: "${DISCONNECTED_REGISTRY}"
@@ -222,11 +222,11 @@ You might want to review the documentation around disconnected registries to lea
     * Option 2: OpenShift Release Image and Release Content in the same path (ocp4), release image copied to a new namespace in the registry (openshiftreleases)
 
         ~~~sh
-        cat <<EOF | oc -n cincinnati-operator create -f -
+        cat <<EOF | oc -n "${NAMESPACE}" create -f -
         apiVersion: cincinnati.openshift.io/v1beta1
         kind: Cincinnati
         metadata:
-          name: disconnected-cincinnati
+          name: example-name
         spec:
           replicas: 1
           registry: "${DISCONNECTED_REGISTRY}"
@@ -237,7 +237,7 @@ You might want to review the documentation around disconnected registries to lea
 3. Check the cincinnati service
 
     ~~~sh
-    curl --header 'Accept:application/json' http://$(oc -n cincinnati-operator get route disconnected-cincinnati-policy-engine-route -o jsonpath='{.spec.host}')/api/upgrades_info/v1/graph\?channel=stable-4.5 | jq
+    curl --header 'Accept:application/json' http://$(oc -n "${NAMESPACE}" get route example-name-policy-engine-route -o jsonpath='{.spec.host}')/api/upgrades_info/v1/graph\?channel=stable-4.5 | jq
     ~~~
 
     > **OUTPUT**
@@ -281,7 +281,7 @@ You might want to review the documentation around disconnected registries to lea
 5. Patch the ClusterVersion to use our Cincinnati instance rather than the public one
 
     ~~~sh
-    CINCINNATI_ROUTE=$(oc -n cincinnati-operator get route disconnected-cincinnati-policy-engine-route -o jsonpath=http://'{.spec.host}'/api/upgrades_info/v1/graph)
+    CINCINNATI_ROUTE=$(oc -n "${NAMESPACE}" get route example-name-policy-engine-route -o jsonpath=http://'{.spec.host}'/api/upgrades_info/v1/graph)
     PATCH="{\"spec\":{\"upstream\":\"${CINCINNATI_ROUTE}\"}}"
     oc patch clusterversion version -p $PATCH --type merge
     ~~~
@@ -313,7 +313,7 @@ You can print the graph for a specific channel in your Cincinnati instance using
 sudo dnf install -y graphviz
 curl -O https://raw.githubusercontent.com/openshift/cincinnati/master/hack/graph.sh
 chmod +x graph.sh
-curl --header 'Accept:application/json' http://disconnected-cincinnati-policy-engine-cincinnati-operator.apps.mgmt-hub.e2e.bos.redhat.com/api/upgrades_info/v1/graph\?channel=stable-4.5 | ./graph.sh | dot -Tpng > graph.png
+curl --header 'Accept:application/json' "http://example-name-policy-engine-${NAMESPACE}.apps.mgmt-hub.e2e.bos.redhat.com/api/upgrades_info/v1/graph?channel=stable-4.5" | ./graph.sh | dot -Tpng > graph.png
 ~~~
 
 ## Mirror the release images

--- a/docs/graph-data-init-container.md
+++ b/docs/graph-data-init-container.md
@@ -35,7 +35,8 @@ For the example above:
 apiVersion: cincinnati.openshift.io/v1beta1
 kind: Cincinnati
 metadata:
-  name: example-cincinnati
+  name: example-name
+  namespace: example-namespace
 spec:
   replicas: 1
   registry: "quay.io"

--- a/pkg/controller/cincinnati/new.go
+++ b/pkg/controller/cincinnati/new.go
@@ -227,7 +227,7 @@ func (k *kubeResources) newPolicyEngineRoute(instance *cv1beta1.Cincinnati) *rou
 			},
 			TLS: &routev1.TLSConfig{
 				Termination:                   routev1.TLSTerminationEdge,
-				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyNone,
 			},
 		},
 	}


### PR DESCRIPTION
Builds on #63; you may want to review that first.

We had used `InsecureEdgeTerminationPolicyAllow` since the route landed in 1fdf865825 (#30).  The motivation for that value didn't make it into the Git commit message, but from [discussion in the GitHub pull request][1], it was:

* `InsecureEdgeTerminationPolicyAllow` is the default termination policy.
* [Cincinnati's docs][2] have no preference.

However, we really, really want HTTPS security for cluster-version operators making upstream requests for update recommendations.  There are long-term plans for tightening down guards against malicious, compromised, or man-in-the-middled update recommendation services, but today we have yet to land even guards as basic as "[upstream is lying about the version string associated with a given release image][3]".

By [removing HTTP termination][4], we force consumers to configure their clients, including the cluster-version operator, with `https://` URIs (or do something else explicit like setting up their own HTTP termination) before they can access the policy-engine output, which reduces the risk that they will recieve and trust compromised update graphs.  This may be a breaking change, but:

* We're still in beta, and not yet in general-availability with backwards-compatability requirements.
* Folks who have configured their cluster-version operators and other clients with `http://` upstreams should *want* to be broken.  We are protecting them from all sorts of compromised-upstream failure modes.
* The cluster-version operator, and other well-behaved clients, will report understandable error messages for "I tried to connect over HTTP and there was nobody there", which will lead users into auditing and fixing their upstream URIs, so recovering from the breakage should not be to onerous.

[1]: https://github.com/openshift/cincinnati-operator/pull/30#discussion_r418741486
[2]: https://github.com/openshift/cincinnati/blame/0bb5f6f3228858f9e5d1807bd6f45f46e537cdea/docs/user/running-cincinnati.md#L87-L88
[3]: https://github.com/openshift/cluster-version-operator/pull/431
[4]: https://github.com/openshift/api/blob/346618ed7d5e6396191efe6f10b2c36f1e95d8b7/route/v1/types.go#L258-L259