### PR TITLE
Dockerfile: Shift to the repo root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.io/openshift/origin-release:golang-1.13 AS builder
+WORKDIR /go/src/github.com/openshift/cincinnati-operator/
+COPY . .
+RUN go build -mod=vendor -o /tmp/build/cincinnati-operator github.com/openshift/cincinnati-operator/cmd/manager
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+COPY --from=builder /tmp/build/cincinnati-operator /usr/bin/cincinnati-operator
+ENTRYPOINT ["/usr/bin/cincinnati-operator"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,9 +1,1 @@
-FROM docker.io/openshift/origin-release:golang-1.13 AS builder
-WORKDIR /go/src/github.com/openshift/cincinnati-operator/
-COPY . .
-RUN go build -mod=vendor -o /tmp/build/cincinnati-operator github.com/openshift/cincinnati-operator/cmd/manager
-
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
-COPY --from=builder /tmp/build/cincinnati-operator /usr/bin/cincinnati-operator
-ENTRYPOINT ["/usr/bin/cincinnati-operator"]
+../Dockerfile


### PR DESCRIPTION
No need to shift this down into a subdirectory.  Add a symlink to give existing consumers some time to migrate.