### PR TITLE
Makefile: Inline the functest invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deploy:
 
 func-test: deploy
 	@echo "Running functional test suite"
-	hack/functest.sh
+	go test -v ./functests/...
 
 unit-test:
 	@echo "Executing unit tests"

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-go test ./functests/...


### PR DESCRIPTION
And drop the one-line functest.sh wrapper.  Also add a `-v` so we get the `t.Log` output to help debug failures.