### PR TITLE
OWNERS: Bugzilla product should be "OpenShift Update Service"

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -21,4 +21,4 @@ reviewers:
 - jottofar
 - vrutkovs
 
-component: "Cincinnati Operator"
+component: OpenShift Update Service


### PR DESCRIPTION
Based on @sdodson's [comment][1]:

> It's used downstream to facilitate mapping to BZ Components.

I'm not sure if this property matters to us, because we are a separate Red Hat product, not a component under the OpenShift Container Project product.  But `Cincinnati Operator` no longer exists anywhere, so pointing folks at our current product name isn't breaking it any worse.

[1]: https://github.com/openshift/cluster-version-operator/pull/344#issuecomment-610902992