### PR TITLE
Dockerfile: Bump builder to ART's Go 1.15 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/openshift/origin-release:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cincinnati-operator/
 COPY . .
 RUN go build -mod=vendor -o /tmp/build/updateservice-operator github.com/openshift/cincinnati-operator


### PR DESCRIPTION
The outgoing docker.io image was [subject to docker.io rate limiting][1]:

```
error: build error: failed to pull image: After retrying 2 times, Pull image still failed due to error: while pulling "docker://docker.io/openshift/origin-release:golang-1.13" as "docker.io/openshift/origin-release:golang-1.13"...
```

The new image matches openshift/cluster-version-operator@7cb2662924 (openshift/cluster-version-operator#468).  Matching builders with the CVO reduces our exposure by consolidating around a smaller set of Go builder images.

[1]: https://github.com/openshift/cincinnati-operator/pull/82#issuecomment-728254564