### PR TITLE
*: Use Git description for version information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/cincinnati-operator/
 COPY . .
-RUN go build -mod=vendor -o /tmp/build/update-service-operator github.com/openshift/cincinnati-operator
+RUN make GOBUILDFLAGS=-mod=vendor VERSION="$(git describe --abbrev=8 --dirty --always)" build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-COPY --from=builder /tmp/build/update-service-operator /usr/bin/update-service-operator
+COPY --from=builder /go/src/github.com/openshift/cincinnati-operator/update-service-operator /usr/bin/update-service-operator
 ENTRYPOINT ["/usr/bin/update-service-operator"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Current Operator version
+VERSION ?= 0.0.1
+
 .PHONY: \
 	clean \
 	deploy \
@@ -6,6 +9,8 @@
 	build
 
 SOURCES := $(shell find . -name '*.go' -not -path "*/vendor/*")
+GOBUILDFLAGS ?= -i -mod=vendor
+GOLDFLAGS ?= -s -w -X github.com/openshift/cincinnati-operator/version.Operator=$(VERSION)
 
 # This is a placeholder for cincinnati-operator image placeholder
 # During development override this when you want to use an specific image
@@ -29,4 +34,4 @@ unit-test:
 	go test -v ./controllers/...
 
 build: $(SOURCES)
-	go build -i -ldflags="-s -w" -mod=vendor -o ./update-service-operator ./
+	go build $(GOBUILDFLAGS) -ldflags="$(GOLDFLAGS)" -o ./update-service-operator ./

--- a/main.go
+++ b/main.go
@@ -47,10 +47,9 @@ func init() {
 }
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
+	log.Info(fmt.Sprintf("Operator Version: %s", version.Operator))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	log.Info(fmt.Sprintf("Version of operator-sdk: %s", version.SdkVersion))
 }
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
+// Package version holds constants declaring component versions.
 package version
 
 var (
-	Version    = "1.0.0"
-	SdkVersion = "v1.2.0"
+	// Operator is the version of the operator.
+	Operator = "was not built correctly"
 )


### PR DESCRIPTION
We've been tracking a nominal operator version since 52a976598c, but this is one more thing we'd need to remember to bump between releases, and it's hard to know what version number we'd want to use before we are building a release.  Drop it from the operator to give us one less moving piece.

I'd be fine including the Git commit hash in some early logging, and injecting that hash at build time, but I've punted on that for now.  The operator images should include that information in the image metadata anyway.

The OLM bundles will remain versioned, but bundle version can be a decision made at bundle-build time, pulling in whichever operator image they want to pull in.