### PR TITLE
OWNERS: Drop Advanced Cluster Management folks

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,24 +1,16 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- mhrivnak
-- rthallisey
-- rwsu
-- LalatenduMohanty
-- wking
-- steveeJ
 - jottofar
+- LalatenduMohanty
+- steveeJ
 - vrutkovs
+- wking
 reviewers:
-- djzager
-- mhrivnak
-- rthallisey
-- rwsu
-- sacharya
-- LalatenduMohanty
-- wking
-- steveeJ
 - jottofar
+- LalatenduMohanty
+- steveeJ
 - vrutkovs
+- wking
 
 component: OpenShift Update Service


### PR DESCRIPTION
The ACM devs kindly scaffolded this operator, but have since handed it off to the updates folks.  This commit completes the ownership transition begun in f7860a3b9b (#62).

I've also applied a case-insensitve sort to the remaining entries.