### PR TITLE
OWNERS: Change 'component' to 'product'

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,4 +13,4 @@ reviewers:
 - vrutkovs
 - wking
 
-component: OpenShift Update Service
+product: OpenShift Update Service


### PR DESCRIPTION
I'd updated the value in 727a3c58f8 (#77), but at that point I was uncertain about how to handle Bugzilla products vs. components.  Today, Luke pointed me towards [the consuming code][1], showing that we should have used the 'product' key, overriding ART's `OpenShift Container Platform` default product.

[1]: https://github.com/openshift/doozer/blob/231d240702a5c22da488fa241bc76df416acee6a/doozerlib/metadata.py#L288-L343