### PR TITLE
Operator bundle: changes to support operator bundling

### DIFF
--- a/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
@@ -1,0 +1,90 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+    description: Creates and maintains an OpenShift Update Service instance
+    operatorframework.io/suggested-namespace: openshift-update-service
+    operators.operatorframework.io/builder: operator-sdk-v1.2.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+  name: update-service-operator.vX.Y.Z
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: UpdateService is the Schema for the updateservices API.
+      displayName: Update Service
+      kind: UpdateService
+      name: updateservices.updateservice.operator.openshift.io
+      version: v1
+  description: |-
+    # Use Case
+    Running an Update Service instance in a cluster is appealing for offline OpenShift
+    clusters or for admins that want to provide their own graph data instead of
+    using [https://github.com/openshift/cincinnati-graph-data](https://github.com/openshift/cincinnati-graph-data/).
+
+    # About Update Service
+    Update Service uses **Cincinnati** which is an update protocol designed to facilitate
+    automatic updates. It describes a particular method for representing transitions between
+    releases of a project and allowing a client to perform automatic updates between these
+    releases.
+
+    ## Components
+    A **Graph Builder** iterates over the release payloads hosted by the
+    storage component and builds a DAG of the releases. It is responsible for
+    verifying that the graph described by the releases is acyclic and connected.
+
+    A **Policy Engine** is in charge of altering a client's view of the graph
+    by applying a set of filters which are defined within the particular Policy
+    Engine instance. Both the input to and the output from Policy Engines is a
+    graph, allowing multiple Policy Engines to be chained together. The first
+    Policy Engine in a chain will fetch its graph from the Graph Builder and the
+    last Policy Engine in a chain will serve the modified graph to the client.
+
+    An **Update Service client** is the end consumer of the release payloads. The
+    client periodically queries the Policy Engine for updates and applys them if
+    available.
+
+    # Query OpenShift's Update Service Endpoint
+    $ curl --silent --header 'Accept:application/json' 'https://api.openshift.com/api/upgrades_info/v1/graph?arch=amd64&channel=stable-4.2' | jq '. as $graph | $graph.nodes | map(.version == "4.2.13") | index(true) as $orig | $graph.edges | map(select(.[0] == $orig)[1]) | map($graph.nodes[.])'
+  displayName: OpenShift Update Service
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments: null
+    strategy: ""
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - Update Service
+  - UpdateService
+  - update-service
+  - OSUS
+  - Cincinnati
+  - version
+  - upgrade
+  links:
+  - name: Update Service Operator
+    url: https://github.com/openshift/cincinnati-operator
+  - name: OpenShift Update Service
+    url: https://github.com/openshift/cincinnati
+  - name: OpenShift Graph Data
+    url: https://github.com/openshift/cincinnati-graph-data
+  maintainers:
+  - email: aos-team-ota@redhat.com
+    name: OpenShift Update Service maintainers
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- ../default
+- ../samples
+- ../scorecard

--- a/config/scorecard/bases/config.yaml
+++ b/config/scorecard/bases/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests: []

--- a/config/scorecard/kustomization.yaml
+++ b/config/scorecard/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- bases/config.yaml
+patchesJson6902:
+- path: patches/basic.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+- path: patches/olm.config.yaml
+  target:
+    group: scorecard.operatorframework.io
+    version: v1alpha3
+    kind: Configuration
+    name: config
+# +kubebuilder:scaffold:patchesJson6902

--- a/config/scorecard/patches/basic.config.yaml
+++ b/config/scorecard/patches/basic.config.yaml
@@ -1,0 +1,10 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: basic
+      test: basic-check-spec-test

--- a/config/scorecard/patches/olm.config.yaml
+++ b/config/scorecard/patches/olm.config.yaml
@@ -1,0 +1,50 @@
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:master
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test


### PR DESCRIPTION
Modifies Makefile and creates the config/manifests artifacts which support bundling and is generated by the new recipe 'gen-for-bundle'.

In its current form this PR assumes that the official build will run the `bundle` target and therefore only needs the `config/manifests` directory. Another possibility is that the official build only builds the bundle image in which case we would run and check-in the results of the `bundle` recipe. The official build would then use these artifacts to build the bundle image which is then used to create or update a bundle index.

The additional recipes added to the Makefile are described in detail below.

`manifests` generates manifests, e.g. CRD, RBAC etc., and is run by development when required.

`gen-for-bundle` generates kustomize bases and a kustomization.yaml used to generate the operator bundle. This was originally part of the `bundle` recipe as generated by the operator-sdk scaffolding. I have broken it out under the assumption that we would run this recipe and check-in the resulting config/manifests directory and contents to the git repo where they would be used by official build tools which actually generate the operator bundle.

`bundle` generates the bundle and metadata as contained in a `bundle` directory and bundle.Dockerfile. A `BUNDLE_VERSION` variable has been added to allow setting bundle version. If it is determined that this is to be ran by development, and not ran as part of the official build, the results of this step should also be checked into git to be used by the official build tools.

`bundle-build` builds the bundle image.