### PR TITLE
Adding SDK version to the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Current Operator version
 VERSION ?= 0.0.1
+VERSIONSDK ?= 1.2.0
 
 .PHONY: \
 	clean \
@@ -14,7 +15,8 @@ VERSION ?= 0.0.1
 
 SOURCES := $(shell find . -name '*.go' -not -path "*/vendor/*")
 GOBUILDFLAGS ?= -i -mod=vendor
-GOLDFLAGS ?= -s -w -X github.com/openshift/cincinnati-operator/version.Operator=$(VERSION)
+GOLDFLAGS ?= -s -w -X github.com/openshift/cincinnati-operator/version.versionOperator=$(VERSION) \
+			-X github.com/openshift/cincinnati-operator/version.versionSDK=$(VERSIONSDK)
 
 # This is a placeholder for cincinnati-operator image placeholder
 # During development override this when you want to use an specific image

--- a/main.go
+++ b/main.go
@@ -47,9 +47,10 @@ func init() {
 }
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Operator Version: %s", version.Operator))
-	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
-	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
+	log.Info(fmt.Sprintf("version: v%s", version.VersionOperator))
+	log.Info(fmt.Sprintf("operator-sdk version: v%s", version.VersionSDK))
+	log.Info(fmt.Sprintf("go Version: %s", runtime.Version()))
+	log.Info(fmt.Sprintf("go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 }
 
 // getWatchNamespace returns the Namespace the operator should be watching for changes

--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@
 package version
 
 var (
+	VersionSDK = "0.0.0-unset"
 	// Operator is the version of the operator.
-	Operator = "was not built correctly"
+	VersionOperator = "0.0.0-unset"
 )


### PR DESCRIPTION
As for creating the operator bundle we need to know which version of
 SDK should be used to generate the manifests

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>