### PR TITLE
Bug 1939788: config/samples: Shorten name

### DIFF
--- a/config/samples/updateservice.operator_v1_updateservice.yaml
+++ b/config/samples/updateservice.operator_v1_updateservice.yaml
@@ -1,7 +1,6 @@
 apiVersion: updateservice.operator.openshift.io/v1
 kind: UpdateService
 metadata:
-  name: updateservice-sample
+  name: sample
 spec:
-  # Add fields here
-  foo: bar
+  replicas: 1


### PR DESCRIPTION
To prevent invalid host error upon route creation. Also replaced incorrect generated spec contents with defaulted "replicas" value.