### PR TITLE
Bug 1945026: Changing the name to make OSBS auto repo/registry replacements to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation docs are [here][operator-sdk-installation].
 To run locally, you must set the operand image as shown below.
 
 ```
-export OPERAND_IMAGE="quay.io/app-sre/cincinnati:2873c6b"
+export RELATED_IMAGE_OPERAND="quay.io/app-sre/cincinnati:2873c6b"
 operator-sdk run --local
 ```
 
@@ -26,7 +26,7 @@ make deploy
 By default, operator will be deployed using the default operator image `quay.io/updateservice/update-service-operator:latest`. If you want to override the default operator image with your image, set 
 
 ```
-export OPERATOR_IMAGE="your-registry/your-repo/your-update-service-opertor-image:tag"
+export RELATED_IMAGE_OPERATOR="your-registry/your-repo/your-update-service-opertor-image:tag"
 ```
 
 ## Run functional tests
@@ -35,7 +35,7 @@ export OPERATOR_IMAGE="your-registry/your-repo/your-update-service-opertor-image
 make func-test
 ```
 
-To run the functional testcases locally, you must set below environment variables as shown below along with optional `OPERAND_IMAGE` and `OPERATOR_IMAGE`.
+To run the functional testcases locally, you must set below environment variables as shown below along with optional `RELATED_IMAGE_OPERAND` and `RELATED_IMAGE_OPERATOR`.
 
 ```
 export KUBECONFIG="path-for-kubeconfig-file"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,5 +26,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "updateservice-operator"
-            - name: OPERAND_IMAGE
+            - name: RELATED_IMAGE_OPERAND
               value: "quay.io/cincinnati/cincinnati:latest"

--- a/config/olm-catalog/updateservice-operator/1.0.0/updateservice-operator.v1.0.0.clusterserviceversion.yaml
+++ b/config/olm-catalog/updateservice-operator/1.0.0/updateservice-operator.v1.0.0.clusterserviceversion.yaml
@@ -97,7 +97,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: updateservice-operator
-                - name: OPERAND_IMAGE
+                - name: RELATED_IMAGE_OPERAND
                   value: quay.io/cincinnati/cincinnati:latest
                 image: quay.io/updateservice/updateservice-operator:latest
                 imagePullPolicy: Always

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -7,14 +7,14 @@ set -e
 DEFAULT_OPERATOR_IMAGE="controller:latest"
 DEFAULT_OPERAND_IMAGE="quay.io/app-sre/cincinnati:2873c6b"
 
-OPERATOR_IMAGE="${OPERATOR_IMAGE:-${DEFAULT_OPERATOR_IMAGE}}"
-OPERAND_IMAGE="${OPERAND_IMAGE:-${DEFAULT_OPERAND_IMAGE}}"
+RELATED_OPERATOR_IMAGE="${RELATED_IMAGE_OPERATOR:-${DEFAULT_OPERATOR_IMAGE}}"
+RELATED_OPERAND_IMAGE="${RELATED_IMAGE_OPERAND:-${DEFAULT_OPERAND_IMAGE}}"
 
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-	OPERATOR_IMAGE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:updateservice-operator"
+	RELATED_OPERATOR_IMAGE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:updateservice-operator"
 	GRAPH_DATA_IMAGE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:updateservice-graph-data-container"
 
-	echo "Openshift CI detected, deploying using image $OPERATOR_IMAGE and ${GRAPH_DATA_IMAGE}"
+	echo "Openshift CI detected, deploying using image $RELATED_OPERATOR_IMAGE and ${GRAPH_DATA_IMAGE}"
 
 else
 	if ! [ -n "$KUBECONFIG" ]; then
@@ -27,8 +27,8 @@ else
 	fi
 fi
 
-sed -i "s|quay.io/cincinnati/cincinnati:latest|$OPERAND_IMAGE|" config/manager/manager.yaml
-sed -i "s|$DEFAULT_OPERATOR_IMAGE|$OPERATOR_IMAGE|" config/manager/manager.yaml
+sed -i "s|quay.io/cincinnati/cincinnati:latest|$RELATED_OPERAND_IMAGE|" config/manager/manager.yaml
+sed -i "s|$DEFAULT_OPERATOR_IMAGE|$RELATED_OPERATOR_IMAGE|" config/manager/manager.yaml
 sed -i "s|your-registry/your-repo/your-init-container|$GRAPH_DATA_IMAGE|" config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml
 
 NAMESPACE="openshift-updateservice"

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -5,7 +5,7 @@ set -e
 # DEFAULT_OPERATOR_IMAGE is a placeholder for cincinnati-operator image placeholder
 # During development override this when you want to use an specific image
 DEFAULT_OPERATOR_IMAGE="controller:latest"
-DEFAULT_OPERAND_IMAGE="quay.io/app-sre/cincinnati:2873c6b"
+DEFAULT_OPERAND_IMAGE="quay.io/cincinnati/cincinnati:latest"
 
 RELATED_OPERATOR_IMAGE="${RELATED_IMAGE_OPERATOR:-${DEFAULT_OPERATOR_IMAGE}}"
 RELATED_OPERAND_IMAGE="${RELATED_IMAGE_OPERAND:-${DEFAULT_OPERAND_IMAGE}}"
@@ -27,7 +27,7 @@ else
 	fi
 fi
 
-sed -i "s|quay.io/cincinnati/cincinnati:latest|$RELATED_OPERAND_IMAGE|" config/manager/manager.yaml
+sed -i "s|$DEFAULT_OPERAND_IMAGE|$RELATED_OPERAND_IMAGE|" config/manager/manager.yaml
 sed -i "s|$DEFAULT_OPERATOR_IMAGE|$RELATED_OPERATOR_IMAGE|" config/manager/manager.yaml
 sed -i "s|your-registry/your-repo/your-init-container|$GRAPH_DATA_IMAGE|" config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml
 

--- a/main.go
+++ b/main.go
@@ -96,9 +96,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	operandImage := os.Getenv("OPERAND_IMAGE")
+	operandImage := os.Getenv("RELATED_IMAGE_OPERAND")
 	if operandImage == "" {
-		log.Error(errors.New("Must set envvar OPERAND_IMAGE"), "")
+		log.Error(errors.New("Must set envvar RELATED_IMAGE_OPERAND"), "")
 		os.Exit(1)
 	}
 	if err = (&controllers.UpdateServiceReconciler{


### PR DESCRIPTION
Changing the name to make OSBS auto repo/registry replacements to work.
Auto digest_pinning, repo_replacements, registry_replacements necessary for releasing the image to different repository (stage, prod) etc. 

Refer
https://osbs.readthedocs.io/en/latest/users.html#pullspec-locations for
details

Also changed OPERATOR_IMAGE to RELATED_IMAGE_OPERATOR for consistency

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>