### PR TITLE
Increasing the go test timeout to 20 minutes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ deploy:
 func-test: deploy
 	@echo "Running functional test suite"
 	go clean -testcache
-	go test -v ./functests/...
+	go test -timeout 20m -v ./functests/...
 
 unit-test:
 	@echo "Executing unit tests"


### PR DESCRIPTION
The CI kept failing in release-4.6 branch and the root cause is the
sracpping time graph-builder container in OSUS operand which is around
 8 minutes or so. However this adds the
total test duration more than 10 mins which causing the test to fail.

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>