### PR TITLE
Expire all test results in the go build cache before new run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ endif
 
 clean:
 	@echo "Cleaning previous outputs"
+	go clean -testcache
 	rm functests/functests.test
 
 deploy:
@@ -51,10 +52,12 @@ deploy:
 
 func-test: deploy
 	@echo "Running functional test suite"
+	go clean -testcache
 	go test -v ./functests/...
 
 unit-test:
 	@echo "Executing unit tests"
+	go clean -testcache
 	go test -v ./controllers/...
 
 build: $(SOURCES)


### PR DESCRIPTION
Else go test was giving success everytime even if the test cluster was
deleted as the result was cached

$ go test -v ./functests/...
=== RUN   TestCustomResource
xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
--- PASS: TestCustomResource (241.87s)
PASS
ok  	github.com/openshift/cincinnati-operator/functests	(cached)