### PR TITLE
controllers/updateservice_controller: Use NotConfigured for "no CAs configured"

### DIFF
--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -194,9 +194,9 @@ func (r *UpdateServiceReconciler) findTrustedCAConfig(ctx context.Context, reqLo
 	// Check if the Cluster is aware of a registry requiring an
 	// AdditionalTrustedCA
 	image := &apicfgv1.Image{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: defaults.ImageConfigName, Namespace: ""}, image)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: defaults.ImageConfigName}, image)
 	if err != nil && errors.IsNotFound(err) {
-		m := fmt.Sprintf("image.config.openshift.io not found for (Name: %v, Namespace: %v)", defaults.ImageConfigName, "")
+		m := fmt.Sprintf("image.config.openshift.io not found for name %s", defaults.ImageConfigName)
 		handleCACertStatus(reqLogger, &instance.Status, "FindAdditionalTrustedCAFailed", m)
 		return nil, nil
 	} else if err != nil {
@@ -204,8 +204,8 @@ func (r *UpdateServiceReconciler) findTrustedCAConfig(ctx context.Context, reqLo
 	}
 
 	if image.Spec.AdditionalTrustedCA.Name == "" {
-		m := fmt.Sprintf("image.config.openshift.io.Spec.AdditionalTrustedCA.Name not found for image (Name: %v, Namespace: %v)", defaults.ImageConfigName, "")
-		handleCACertStatus(reqLogger, &instance.Status, "FindAdditionalTrustedCAFailed", m)
+		m := fmt.Sprintf("image.config.openshift.io.Spec.AdditionalTrustedCA.Name not set for image name %s", defaults.ImageConfigName)
+		handleCACertStatus(reqLogger, &instance.Status, "NotConfigured", m)
 		return nil, nil
 	}
 


### PR DESCRIPTION
Before this commit:

```console
$ oc -n openshift-update-service get -o yaml updateservice sample
...
status:
  conditions:
  - lastHeartbeatTime: "2021-07-21T16:29:15Z"
    lastTransitionTime: "2021-07-21T16:29:15Z"
    message: 'image.config.openshift.io.Spec.AdditionalTrustedCA.Name not found for
      image (Name: cluster, Namespace: )'
    reason: FindAdditionalTrustedCAFailed
    status: "False"
    type: RegistryCACertFound
...
```

Which is a bit alarming for the "no registry CAs injected; you're fine".  This commit will pivot to a `NotConfigured` reason and a clearer message:

    image.config.openshift.io.Spec.AdditionalTrustedCA.Name not set for image name cluster

I'm also dropping the rendered namespace, because [the Image config is cluster-namespaced][1].

[1]: https://github.com/openshift/api/blob/a99ffa1cac6709edf8f502b16890b16f9a557e00/config/v1/types_image.go#L6