### PR TITLE
Fixing the operator container image name

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,6 +25,6 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
-              value: "updateservice-operator"
+              value: "cincinnati-operator"
             - name: RELATED_IMAGE_OPERAND
               value: "quay.io/cincinnati/cincinnati:latest"


### PR DESCRIPTION
As the container image name is cincinnati-operator in downstream build
system as well as in the upstream docs. In future we will work towards make the updateservice name consistent. 

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>