### PR TITLE
Modify CRD so passes all scorecard tests

### DIFF
--- a/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
@@ -19,6 +19,12 @@ spec:
       kind: UpdateService
       name: updateservices.updateservice.operator.openshift.io
       version: v1
+      resources:
+      - kind: Service
+      specDescriptors:
+      - path: replicas
+      statusDescriptors:
+      - path: replicas
   description: |-
     # Use Case
     Running an Update Service instance in a cluster is appealing for offline OpenShift


### PR DESCRIPTION
After moving to v1.9.0 3 three scorecard tests were failing. The full output of the failed scorecard tests is below. 
The first "olm-status-descriptors" was addressed by adding `statusDescriptors`, the second "olm-crds-have-resources" by adding `resources`, and the third "olm-spec-descriptors" by adding `specDescriptors`.  These are described [here](https://sdk.operatorframework.io/docs/olm-integration/generation/#csv-fields).

`{
      "kind": "Test",
      "apiVersion": "scorecard.operatorframework.io/v1alpha3",
      "spec": {
        "image": "quay.io/operator-framework/scorecard-test:v1.9.0",
        "entrypoint": [
          "scorecard-test",
          "olm-status-descriptors"
        ],
        "labels": {
          "suite": "olm",
          "test": "olm-status-descriptors-test"
        }
      },
      "status": {
        "results": [
          {
            "name": "olm-status-descriptors",
            "log": "Loaded ClusterServiceVersion: update-service-operator.v4.9.0\nLoaded 1 Custom Resources from alm-examples\n",
            "state": "fail",
            "errors": [
              "updateservices.updateservice.operator.openshift.io does not have a status descriptor"
            ]
          }
        ]
      }
    },`

`
{
      "kind": "Test",
      "apiVersion": "scorecard.operatorframework.io/v1alpha3",
      "spec": {
        "image": "quay.io/operator-framework/scorecard-test:v1.9.0",
        "entrypoint": [
          "scorecard-test",
          "olm-crds-have-resources"
        ],
        "labels": {
          "suite": "olm",
          "test": "olm-crds-have-resources-test"
        }
      },
      "status": {
        "results": [
          {
            "name": "olm-crds-have-resources",
            "log": "Loaded ClusterServiceVersion: update-service-operator.v4.9.0\n",
            "state": "fail",
            "errors": [
              "Owned CRDs do not have resources specified"
            ]
          }
        ]
      }
    },`

`
{
      "kind": "Test",
      "apiVersion": "scorecard.operatorframework.io/v1alpha3",
      "spec": {
        "image": "quay.io/operator-framework/scorecard-test:v1.9.0",
        "entrypoint": [
          "scorecard-test",
          "olm-spec-descriptors"
        ],
        "labels": {
          "suite": "olm",
          "test": "olm-spec-descriptors-test"
        }
      },
      "status": {
        "results": [
          {
            "name": "olm-spec-descriptors",
            "log": "Loaded ClusterServiceVersion: update-service-operator.v4.9.0\nLoaded 1 Custom Resources from alm-examples\n",
            "state": "fail",
            "errors": [
              "replicas does not have a spec descriptor"
            ],
            "suggestions": [
              "Add a spec descriptor for replicas"
            ]
          }
        ]
      }`
