### PR TITLE
controllers/new: Always pull graph-data images

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -422,7 +422,7 @@ func (k *kubeResources) newGraphDataInitContainer(instance *cv1.UpdateService) *
 	return &corev1.Container{
 		Name:            NameInitContainerGraphData,
 		Image:           instance.Spec.GraphDataImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
+		ImagePullPolicy: corev1.PullAlways,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "cincinnati-graph-data",


### PR DESCRIPTION
[Official docs recommend][1]:

```yaml
graphDataImage: registry.example.com/openshift/graph-data:latest
```

That's a mutable tag, so pull-if-not-present will not fetch new data when graph-data changes.  Moving to `Always` will ensure we have fresh data.  Before this commit, the tedious mitigation is to use by-digest pullspecs instead of by-tag pullspecs, and to explicitly bump the digest to push out your fresh graph-data.

This can create some slight overhead when the target container has not changed since the last pull.  And in extreme cases where the canonical registry and all configured mirrors are down, it would prevent the operand pod from launching entirely.  But I think the appropriate mitigation for that is to configure a working mirror registry.  And though [the upstream docs][2] are not clear on this point, I see no benefit to contacting a registry about a by-digest pullspec that is already available locally; perhaps the kubelet will not attempt registry access if you use a by-digest pullspec.

[1]: https://docs.openshift.com/container-platform/4.8/updating/installing-update-service.html#update-service-create-service
[2]: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy