### PR TITLE
OTA-378: Refine OSUS Operator for better UX and error proofing

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,12 +18,14 @@ spec:
           image: controller:latest
           imagePullPolicy: Always
           env:
-            - name: WATCH_NAMESPACE
-              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "updateservice-operator"
             - name: RELATED_IMAGE_OPERAND

--- a/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
@@ -66,11 +66,11 @@ spec:
   installModes:
   - supported: true
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - Update Service

--- a/controllers/mapper.go
+++ b/controllers/mapper.go
@@ -23,7 +23,7 @@ func (m *mapper) Map(obj client.Object) []reconcile.Request {
 	if cm, ok := obj.(*corev1.ConfigMap); ok {
 		// There is already a watch on local configMap as a secondary resource
 		// This watch is for the source configMap in openshift-config namespace
-		if cm.Namespace != openshiftConfigNamespace {
+		if cm.Namespace != OpenshiftConfigNamespace {
 			return []reconcile.Request{}
 		}
 		image := &apicfgv1.Image{}

--- a/controllers/mapper_test.go
+++ b/controllers/mapper_test.go
@@ -98,7 +98,7 @@ func TestMap(t *testing.T) {
 			configMap: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      testConfigMap,
-					Namespace: openshiftConfigNamespace,
+					Namespace: OpenshiftConfigNamespace,
 				},
 			},
 			existingObjs: []runtime.Object{

--- a/controllers/names.go
+++ b/controllers/names.go
@@ -12,8 +12,8 @@ const (
 	NameContainerPolicyEngine string = "policy-engine"
 	// NameInitContainerGraphData is the Name property of the graph data container
 	NameInitContainerGraphData string = "graph-data"
-	// openshiftConfigNamespace is the name of openshift's configuration namespace
-	openshiftConfigNamespace = "openshift-config"
+	// OpenshiftConfigNamespace is the name of openshift's configuration namespace
+	OpenshiftConfigNamespace = "openshift-config"
 	// NameTrustedCAVolume is the name of the Volume used in UpdateService's deployment containing the CA Cert
 	NameTrustedCAVolume = "trusted-ca"
 	// NameCertConfigMapKey is the ConfigMap key name where the operator expects the external registry CA Cert

--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -578,8 +578,9 @@ func newRequest(updateservice *cv1.UpdateService) reconcile.Request {
 func newTestReconciler(initObjs ...runtime.Object) *UpdateServiceReconciler {
 	c := fake.NewFakeClientWithScheme(scheme.Scheme, initObjs...)
 	return &UpdateServiceReconciler{
-		Client: c,
-		Scheme: scheme.Scheme,
+		Client:            c,
+		Scheme:            scheme.Scheme,
+		OperatorNamespace: "bar",
 	}
 }
 
@@ -618,7 +619,7 @@ func newConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testConfigMap,
-			Namespace: openshiftConfigNamespace,
+			Namespace: OpenshiftConfigNamespace,
 		},
 		Data: map[string]string{
 			"testData": "some random text",
@@ -630,7 +631,7 @@ func newSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namePullSecret,
-			Namespace: openshiftConfigNamespace,
+			Namespace: OpenshiftConfigNamespace,
 		},
 		Data: map[string][]byte{
 			"testData": []byte("some random text"),


### PR DESCRIPTION
Changes:

1. Operator will only `Reconcile` operands (OSUS apps) created, or already running, in the same namespace as the operator.
2. Disabled AllNamespaces installation mode since this PR restricts OSUS operator namespace watching to `openshift-config` and the namespace in which the operator is installed.
