### PR TITLE
Set additionalPrinterColumns for UpdateService CRD

### DIFF
--- a/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
+++ b/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
@@ -99,6 +99,31 @@ spec:
         - metadata
         - spec
         type: object
+    additionalPrinterColumns:
+    - name: Age 
+      description: The age of the UpdateService resource.
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Policy Engine URI
+      description: The external URI which exposes the policy engine.
+      type: string
+      priority: 1
+      jsonPath: .status.policyEngineURI
+    - name: Releases
+      description: The repository in which release images are tagged.
+      type: string
+      priority: 1
+      jsonPath: .spec.releases
+    - name: Graph Data Image
+      description: The container image that contains the UpdateService graph data.
+      type: string
+      priority: 1
+      jsonPath: .spec.graphDataImage
+    - name: Reconcile Completed
+      description: Status reports whether all required resources have been created in the cluster and reflect the specified state.
+      type: string
+      priority: 1
+      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
Set `additionalPrinterColumns` for UpdateService CRD to provide more information to a user about the UpdateService resource.

Previously running the `oc get -o wide ...` command only displayed the name and the age of the specific running UpdateService resources.

Display the `policyEngineURI`, `releases`, `graphDataImage`, and the `ReconcileCompleted` condition status to provide more information to a user about the UpdateService resource. Set the priority of these `additionalPrinterColumns` accordingly to list them only when the `-o wide` flag is provided.

Pull request is related to https://issues.redhat.com/browse/OTA-449