### PR TITLE
Use http probe for policy-engine

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -594,8 +594,10 @@ func (k *kubeResources) newPolicyEngineContainer(instance *cv1.UpdateService, im
 			PeriodSeconds:       10,
 			TimeoutSeconds:      3,
 			Handler: corev1.Handler{
-				TCPSocket: &corev1.TCPSocketAction{
-					Port: intstr.FromInt(8081),
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/metrics",
+					Port:   intstr.FromInt(9081),
+					Scheme: corev1.URISchemeHTTP,
 				},
 			},
 		},


### PR DESCRIPTION
This allows us to use keep-alived connection to check that policy-engine is still running. This becomes important under load, when a new liveness probe connection becomes expensive.