### PR TITLE
deploy.sh: show image pull specs when deploying

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # DEFAULT_OPERATOR_IMAGE is a placeholder for cincinnati-operator image placeholder
 # During development override this when you want to use an specific image
@@ -10,22 +10,16 @@ DEFAULT_OPERAND_IMAGE="quay.io/cincinnati/cincinnati:latest"
 RELATED_OPERATOR_IMAGE="${RELATED_IMAGE_OPERATOR:-${DEFAULT_OPERATOR_IMAGE}}"
 RELATED_OPERAND_IMAGE="${RELATED_IMAGE_OPERAND:-${DEFAULT_OPERAND_IMAGE}}"
 
-if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-	RELATED_OPERATOR_IMAGE="registry.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:updateservice-operator"
-	GRAPH_DATA_IMAGE="registry.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:updateservice-graph-data-container"
-
-	echo "Openshift CI detected, deploying using image $RELATED_OPERATOR_IMAGE and ${GRAPH_DATA_IMAGE}"
-
-else
-	if ! [ -n "$KUBECONFIG" ]; then
-		echo "KUBECONFIG environment variable must be set."
-		exit 1
-	fi
-	if ! [ -n "$GRAPH_DATA_IMAGE" ]; then
-		echo "GRAPH_DATA_IMAGE environment variable must be set."
-		exit 1
-	fi
+if ! [ -n "$KUBECONFIG" ]; then
+	echo "KUBECONFIG environment variable must be set."
+	exit 1
 fi
+if ! [ -n "$GRAPH_DATA_IMAGE" ]; then
+	echo "GRAPH_DATA_IMAGE environment variable must be set."
+	exit 1
+fi
+
+echo "Deploying using ${RELATED_OPERATOR_IMAGE} as operator, ${RELATED_OPERAND_IMAGE} as operand and ${GRAPH_DATA_IMAGE} as graph data image"
 
 sed -i "s|$DEFAULT_OPERAND_IMAGE|$RELATED_OPERAND_IMAGE|" config/manager/manager.yaml
 sed -i "s|$DEFAULT_OPERATOR_IMAGE|$RELATED_OPERATOR_IMAGE|" config/manager/manager.yaml


### PR DESCRIPTION
Removed openshift CI case as its no longer being used (image pullspecs are passed as RELATED_IMAGE_OPERATOR/RELATED_IMAGE_OPERAND/GRAPH_DATA_IMAGE env vars)