### PR TITLE
Migrate policy/v1beta1 PodDisruptionBudget to policy/v1

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -12,7 +12,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -76,7 +76,7 @@ type kubeResources struct {
 	envConfigHash            string
 	graphBuilderConfig       *corev1.ConfigMap
 	graphBuilderConfigHash   string
-	podDisruptionBudget      *policyv1beta1.PodDisruptionBudget
+	podDisruptionBudget      *policyv1.PodDisruptionBudget
 	deployment               *appsv1.Deployment
 	graphBuilderContainer    *corev1.Container
 	graphDataInitContainer   *corev1.Container
@@ -131,14 +131,14 @@ func newKubeResources(instance *cv1.UpdateService, image string, pullSecret *cor
 	return &k, nil
 }
 
-func (k *kubeResources) newPodDisruptionBudget(instance *cv1.UpdateService) *policyv1beta1.PodDisruptionBudget {
+func (k *kubeResources) newPodDisruptionBudget(instance *cv1.UpdateService) *policyv1.PodDisruptionBudget {
 	minAvailable := getMinAvailablePBD(instance)
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      namePodDisruptionBudget(instance),
 			Namespace: instance.Namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -11,7 +11,7 @@ import (
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -265,7 +265,6 @@ func (r *UpdateServiceReconciler) findTrustedCAConfig(ctx context.Context, reqLo
 	return sourceCM, nil
 }
 
-
 // findTrustedCAConfig - Locate the ConfigMap referenced by the ImageConfig resource in openshift-config and return it
 func (r *UpdateServiceReconciler) findTrustedClusterCAConfig(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService) (*corev1.ConfigMap, error) {
 
@@ -277,15 +276,13 @@ func (r *UpdateServiceReconciler) findTrustedClusterCAConfig(ctx context.Context
 	}
 
 	if _, ok := sourceCM.Data[NameClusterCertConfigMapKey]; !ok {
-		m := fmt.Sprintf("Found cluster-wide CA but required key: '%v' not found", NameClusterCertConfigMapKey )
+		m := fmt.Sprintf("Found cluster-wide CA but required key: '%v' not found", NameClusterCertConfigMapKey)
 		handleCACertStatus(reqLogger, &instance.Status, "EnsureTrustedClusterCAFailed", m)
 		return nil, nil
 	}
 
 	return sourceCM, nil
 }
-
-
 
 func (r *UpdateServiceReconciler) ensurePullSecret(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
 	if resources.pullSecret == nil {
@@ -490,7 +487,7 @@ func (r *UpdateServiceReconciler) ensurePodDisruptionBudget(ctx context.Context,
 	}
 
 	// Check if it already exists
-	found := &policyv1beta1.PodDisruptionBudget{}
+	found := &policyv1.PodDisruptionBudget{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: pdb.Name, Namespace: pdb.Namespace}, found)
 	if err != nil && apiErrors.IsNotFound(err) {
 		reqLogger.Info("Creating PodDisruptionBudget", "Namespace", pdb.Namespace, "Name", pdb.Name)
@@ -750,7 +747,7 @@ func (r *UpdateServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
-		Owns(&policyv1beta1.PodDisruptionBudget{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&routev1.Route{}).
 		Watches(
 			&source.Kind{Type: &apicfgv1.Image{}},

--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -16,7 +16,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -503,7 +503,7 @@ func TestEnsurePodDisruptionBudget(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			found := &policyv1beta1.PodDisruptionBudget{}
+			found := &policyv1.PodDisruptionBudget{}
 			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: namePodDisruptionBudget(updateservice), Namespace: updateservice.Namespace}, found)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
As policy/v1beta1 API version of PodDisruptionBudget is no longer served as of OCP 4.12 i.e. kubernetes v1.25

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>