### PR TITLE
add liveness and readiness probe for PE 

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -704,12 +704,26 @@ func (k *kubeResources) newPolicyEngineContainer(instance *cv1.UpdateService, im
 		LivenessProbe: &corev1.Probe{
 			FailureThreshold:    3,
 			SuccessThreshold:    1,
-			InitialDelaySeconds: 3,
-			PeriodSeconds:       10,
+			InitialDelaySeconds: 120,
+			PeriodSeconds:       30,
 			TimeoutSeconds:      3,
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path:   "/metrics",
+					Path:   "/livez",
+					Port:   intstr.FromInt(9081),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+		},
+		ReadinessProbe: &corev1.Probe{
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			InitialDelaySeconds: 120,
+			PeriodSeconds:       30,
+			TimeoutSeconds:      3,
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/readyz",
 					Port:   intstr.FromInt(9081),
 					Scheme: corev1.URISchemeHTTP,
 				},


### PR DESCRIPTION
add the liveness and readiness probes added to
cincinnati operand since https://github.com/openshift/cincinnati/pull/740