### PR TITLE
init Dockerfile: Fix tar error setting user

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -2,6 +2,6 @@ FROM registry.access.redhat.com/ubi8/ubi:8.1
 
 RUN curl -L -o cincinnati-graph-data.tar.gz https://api.openshift.com/api/upgrades_info/graph-data
 
-RUN mkdir -p /var/lib/cincinnati-graph-data && tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati-graph-data/ --no-overwrite-dir
+RUN mkdir -p /var/lib/cincinnati-graph-data && tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati-graph-data/ --no-overwrite-dir --no-same-owner
 
 CMD ["/bin/bash", "-c" ,"exec cp -rp /var/lib/cincinnati-graph-data/* /var/lib/cincinnati/graph-data"]


### PR DESCRIPTION
Since tar is run as root, it will attempt to preserve the user/group of the files in the archive by default, which leads to these errors when unpacking the graph data archive:

tar: version: Cannot change ownership to uid 1000950000, gid 0: Invalid argument

Passing the --no-same-owner flag to tar will expand the archive contents as root:root instead of trying to preserve the non-existent uid from the original archive.