### PR TITLE
functests: stop using v1beta1 PDB API

### DIFF
--- a/functests/updateservice_creation_test.go
+++ b/functests/updateservice_creation_test.go
@@ -113,7 +113,7 @@ func TestCustomResource(t *testing.T) {
 	// Checks to see if a given PodDisruptionBudget is available after a specified amount of time.
 	// If the PodDisruptionBudget is not available after 30 * retries seconds, the condition function returns an error.
 	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		if _, err := k8sClient.PolicyV1beta1().PodDisruptionBudgets(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{}); err != nil {
+		if _, err := k8sClient.PolicyV1().PodDisruptionBudgets(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
 				t.Logf("Waiting for availability of %s PodDisruptionBudget\n", operatorName)
 				return false, nil


### PR DESCRIPTION
This makes the tests work against OCP 4.12+ clusters. The failure can be seen e.g. in [this rehearsal](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/39394/rehearse-39394-pull-ci-openshift-cincinnati-operator-master-operator-e2e-latest-osus-412/1658587442212507648).