### PR TITLE
Include bundle manifests and Dockerfile

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,21 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=update-service-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=v1
+LABEL operators.operatorframework.io.bundle.channel.default.v1=v1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0-ocp
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/

--- a/bundle/manifests/leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/leader-election-role_rbac.authorization.k8s.io_v1_role.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: leader-election-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/bundle/manifests/leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/leader-election-rolebinding_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: leader-election-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/bundle/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/bundle/manifests/proxy-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/proxy-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/bundle/manifests/proxy-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/bundle/manifests/proxy-rolebinding_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: proxy-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -1,0 +1,253 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "updateservice.operator.openshift.io/v1",
+          "kind": "UpdateService",
+          "metadata": {
+            "name": "sample"
+          },
+          "spec": {
+            "replicas": 1
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2023-08-09T15:46:12Z"
+    description: Creates and maintains an OpenShift Update Service instance
+    operatorframework.io/suggested-namespace: openshift-update-service
+    operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+  name: update-service-operator.v5.0.2-dev
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: UpdateService is the Schema for the updateservices API.
+      displayName: Update Service
+      kind: UpdateService
+      name: updateservices.updateservice.operator.openshift.io
+      resources:
+      - kind: Service
+        name: ""
+        version: ""
+      specDescriptors:
+      - path: replicas
+      statusDescriptors:
+      - path: replicas
+      version: v1
+  description: |-
+    # Use Case
+    Running an Update Service instance in a cluster is appealing for offline OpenShift
+    clusters or for admins that want to provide their own graph data instead of
+    using [https://github.com/openshift/cincinnati-graph-data](https://github.com/openshift/cincinnati-graph-data/).
+
+    # About Update Service
+    Update Service uses **Cincinnati** which is an update protocol designed to facilitate
+    automatic updates. It describes a particular method for representing transitions between
+    releases of a project and allowing a client to perform automatic updates between these
+    releases.
+
+    ## Components
+    A **Graph Builder** iterates over the release payloads hosted by the
+    storage component and builds a DAG of the releases. It is responsible for
+    verifying that the graph described by the releases is acyclic and connected.
+
+    A **Policy Engine** is in charge of altering a client's view of the graph
+    by applying a set of filters which are defined within the particular Policy
+    Engine instance. Both the input to and the output from Policy Engines is a
+    graph, allowing multiple Policy Engines to be chained together. The first
+    Policy Engine in a chain will fetch its graph from the Graph Builder and the
+    last Policy Engine in a chain will serve the modified graph to the client.
+
+    An **Update Service client** is the end consumer of the release payloads. The
+    client periodically queries the Policy Engine for updates and applys them if
+    available.
+
+    # Query OpenShift's Update Service Endpoint
+    $ curl --silent --header 'Accept:application/json' 'https://api.openshift.com/api/upgrades_info/v1/graph?arch=amd64&channel=stable-4.2' | jq '. as $graph | $graph.nodes | map(.version == "4.2.13") | index(true) as $orig | $graph.edges | map(select(.[0] == $orig)[1]) | map($graph.nodes[.])'
+  displayName: OpenShift Update Service
+  icon:
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxOTIgMTQ1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2UwMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlJlZEhhdC1Mb2dvLUhhdC1Db2xvcjwvdGl0bGU+PHBhdGggZD0iTTE1Ny43Nyw2Mi42MWExNCwxNCwwLDAsMSwuMzEsMy40MmMwLDE0Ljg4LTE4LjEsMTcuNDYtMzAuNjEsMTcuNDZDNzguODMsODMuNDksNDIuNTMsNTMuMjYsNDIuNTMsNDRhNi40Myw2LjQzLDAsMCwxLC4yMi0xLjk0bC0zLjY2LDkuMDZhMTguNDUsMTguNDUsMCwwLDAtMS41MSw3LjMzYzAsMTguMTEsNDEsNDUuNDgsODcuNzQsNDUuNDgsMjAuNjksMCwzNi40My03Ljc2LDM2LjQzLTIxLjc3LDAtMS4wOCwwLTEuOTQtMS43My0xMC4xM1oiLz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMjcuNDcsODMuNDljMTIuNTEsMCwzMC42MS0yLjU4LDMwLjYxLTE3LjQ2YTE0LDE0LDAsMCwwLS4zMS0zLjQybC03LjQ1LTMyLjM2Yy0xLjcyLTcuMTItMy4yMy0xMC4zNS0xNS43My0xNi42QzEyNC44OSw4LjY5LDEwMy43Ni41LDk3LjUxLjUsOTEuNjkuNSw5MCw4LDgzLjA2LDhjLTYuNjgsMC0xMS42NC01LjYtMTcuODktNS42LTYsMC05LjkxLDQuMDktMTIuOTMsMTIuNSwwLDAtOC40MSwyMy43Mi05LjQ5LDI3LjE2QTYuNDMsNi40MywwLDAsMCw0Mi41Myw0NGMwLDkuMjIsMzYuMywzOS40NSw4NC45NCwzOS40NU0xNjAsNzIuMDdjMS43Myw4LjE5LDEuNzMsOS4wNSwxLjczLDEwLjEzLDAsMTQtMTUuNzQsMjEuNzctMzYuNDMsMjEuNzdDNzguNTQsMTA0LDM3LjU4LDc2LjYsMzcuNTgsNTguNDlhMTguNDUsMTguNDUsMCwwLDEsMS41MS03LjMzQzIyLjI3LDUyLC41LDU1LC41LDc0LjIyYzAsMzEuNDgsNzQuNTksNzAuMjgsMTMzLjY1LDcwLjI4LDQ1LjI4LDAsNTYuNy0yMC40OCw1Ni43LTM2LjY1LDAtMTIuNzItMTEtMjcuMTYtMzAuODMtMzUuNzgiLz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resourceNames:
+          - updateservice-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - images
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - updateservice.operator.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: updateservice-operator
+      deployments:
+      - name: updateservice-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: updateservice-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: updateservice-operator
+            spec:
+              containers:
+              - env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_NAME
+                  value: updateservice-operator
+                - name: RELATED_IMAGE_OPERAND
+                  value: quay.io/cincinnati/cincinnati:latest
+                image: controller:latest
+                imagePullPolicy: Always
+                name: updateservice-operator
+                resources: {}
+              serviceAccountName: updateservice-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - Update Service
+  - UpdateService
+  - update-service
+  - OSUS
+  - Cincinnati
+  - version
+  - upgrade
+  links:
+  - name: Update Service Operator
+    url: https://github.com/openshift/cincinnati-operator
+  - name: OpenShift Update Service
+    url: https://github.com/openshift/cincinnati
+  - name: OpenShift Graph Data
+    url: https://github.com/openshift/cincinnati-graph-data
+  maintainers:
+  - email: aos-team-ota@redhat.com
+    name: OpenShift Update Service maintainers
+  maturity: alpha
+  provider:
+    name: Red Hat
+  relatedImages:
+  - image: quay.io/cincinnati/cincinnati:latest
+    name: operand
+  version: 5.0.2-dev

--- a/bundle/manifests/updateservice-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/updateservice-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: updateservice-operator
+  name: updateservice-operator-metrics-monitor
+spec:
+  endpoints:
+  - path: /metrics
+    port: https
+  selector:
+    matchLabels:
+      control-plane: updateservice-operator

--- a/bundle/manifests/updateservice-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/updateservice-operator-metrics_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    control-plane: updateservice-operator
+  name: updateservice-operator-metrics
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: updateservice-operator
+status:
+  loadBalancer: {}

--- a/bundle/manifests/updateservice-operator_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/updateservice-operator_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: updateservice-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: updateservice-operator
+subjects:
+- kind: ServiceAccount
+  name: updateservice-operator
+  namespace: openshift-updateservice

--- a/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
+++ b/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
@@ -1,0 +1,135 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: updateservices.updateservice.operator.openshift.io
+spec:
+  group: updateservice.operator.openshift.io
+  names:
+    kind: UpdateService
+    listKind: UpdateServiceList
+    plural: updateservices
+    singular: updateservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The age of the UpdateService resource.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The external URI which exposes the policy engine.
+      jsonPath: .status.policyEngineURI
+      name: Policy Engine URI
+      priority: 1
+      type: string
+    - description: The repository in which release images are tagged.
+      jsonPath: .spec.releases
+      name: Releases
+      priority: 1
+      type: string
+    - description: The container image that contains the UpdateService graph data.
+      jsonPath: .spec.graphDataImage
+      name: Graph Data Image
+      priority: 1
+      type: string
+    - description: Status reports whether all required resources have been created
+        in the cluster and reflect the specified state.
+      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
+      name: Reconcile Completed
+      priority: 1
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: UpdateService is the Schema for the updateservices API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          spec:
+            description: spec is the desired state of the UpdateService service.  The
+              operator will work to ensure that the desired configuration is applied
+              to the cluster.
+            properties:
+              graphDataImage:
+                description: graphDataImage is a container image that contains the
+                  UpdateService graph data.
+                type: string
+              releases:
+                description: releases is the repository in which release images are
+                  tagged, such as quay.io/openshift-release-dev/ocp-release.
+                type: string
+              replicas:
+                description: replicas is the number of pods to run. When >=2, a PodDisruptionBudget
+                  will ensure that voluntary disruption leaves at least one Pod running
+                  at all times.
+                format: int32
+                minimum: 1
+                type: integer
+            required:
+            - graphDataImage
+            - releases
+            - replicas
+            type: object
+          status:
+            description: status contains information about the current state of the
+              UpdateService service.
+            properties:
+              conditions:
+                description: Conditions describe the state of the UpdateService resource.
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              policyEngineURI:
+                description: "policyEngineURI is the external URI which exposes the
+                  policy engine.  Available paths from this URI include: \n * /api/upgrades_info/v1/graph,
+                  with the update graph recommendations."
+                type: string
+            required:
+            - policyEngineURI
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: update-service-operator
+  operators.operatorframework.io.bundle.channels.v1: v1
+  operators.operatorframework.io.bundle.channel.default.v1: v1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0-ocp
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/bundle/tests/scorecard/config.yaml
+++ b/bundle/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.9.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.9.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.9.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.9.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.9.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.9.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest


### PR DESCRIPTION
Just ran an existing `Makefile` target /shrug:

```console
$ make bundle VERSION=5.0.2-dev
cd config/manager && /usr/bin/kustomize edit set image controller=controller:latest
/usr/bin/kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version 5.0.2-dev --channels=v1 --default-channel=v1
INFO[0000] Creating bundle.Dockerfile                   
INFO[0000] Creating bundle/metadata/annotations.yaml    
INFO[0000] Bundle metadata generated successfully       
operator-sdk bundle validate ./bundle
INFO[0000] All validation tests have completed successfully
```

The bundle will not work by itself: we are not publishing the operator images anywhere (except the productized images ofc) and we are not publishing cincinnati images anywhere suitable either (quay.io/cincinnati/cincinnati:latest is stale and quay.io/app-sre/cincinnati does not have floating or even version tags). 

So for now this work should just support building the bundles from pull request code for the purpose of testing operator and operand PRs in CI and by QE, see https://github.com/openshift/release/pull/42053
