### PR TITLE
Revert "OCPBUGS-16898 : Add both trusted and additional CA to SSL_CERT_DIR"

### DIFF
--- a/controllers/names.go
+++ b/controllers/names.go
@@ -26,8 +26,6 @@ const (
 	namePullSecret = "pull-secret"
 	// ClusterCAMountDir is the mount path for the dir containing cluster CA
 	ClusterCAMountDir = "/etc/pki/ca-trust/extracted/cluster-ca/"
-	// SSLCertDir is the directory where all the SSL_CERTs are kept
-	SSLCertDir = "/etc/pki/ca-trust/extracted/pem"
 )
 
 func nameDeployment(instance *cv1.UpdateService) string {

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -538,14 +538,8 @@ func (k *kubeResources) newGraphBuilderContainer(instance *cv1.UpdateService, im
 	if k.trustedClusterCAConfig != nil {
 		gbENV = append(gbENV,
 			corev1.EnvVar{
-				Name:  "CLUSTER_CERT_DIR",
-				Value: ClusterCAMountDir,
-			},
-		)
-		gbENV = append(gbENV,
-			corev1.EnvVar{
-				Name:  "SSL_CERT_DIR",
-				Value: SSLCertDir + ":" + ClusterCAMountDir,
+				Name:  "SSL_CERT_FILE",
+				Value: ClusterCAMountDir + NameClusterCertConfigMapKey,
 			},
 		)
 	}
@@ -639,7 +633,7 @@ func (k *kubeResources) newGraphBuilderVolumeMounts(instance *cv1.UpdateService)
 		vm = append(vm, corev1.VolumeMount{
 			Name:      NameTrustedCAVolume,
 			ReadOnly:  true,
-			MountPath: SSLCertDir,
+			MountPath: "/etc/pki/ca-trust/extracted/pem",
 		})
 	}
 	if k.trustedClusterCAConfig != nil {

--- a/docs/external-registry-ca.md
+++ b/docs/external-registry-ca.md
@@ -1,10 +1,9 @@
 # External Registry CA Injection
 
-**Note:** In a disconnected cluster with cluster-wide CA, Cincinnati will use the pre-configured CA certificates 
-to access the external registry. 
-
 If you are using a secure external container registry to hold mirrored OpenShift
-release images for which the CA certificates are not added to cluster-wide CA, Cincinnati will need access to this registry in order to build an upgrade graph.  Here's how you can inject your CA Cert into the Cincinnati pod.
+release images, Cincinnati will need access to this registry in order to build
+an upgrade graph.  Here's how you can inject your CA Cert into the Cincinnati
+pod.
 
 OpenShift has an external registry API, located at `image.config.openshift.io`,
 that we'll use to store the external registry CA Cert.  You can read more about


### PR DESCRIPTION
Reverts openshift/cincinnati-operator#172

We will fix the bug with another approach.
For now, we'll prefer cluster-wide-proxy over additionalTrustedCAs