### PR TITLE
OTA-1014: bundle/manifests: Update UpdateService CRD to pick up metadataURI

### DIFF
--- a/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
+++ b/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: updateservices.updateservice.operator.openshift.io
 spec:
   group: updateservice.operator.openshift.io
@@ -14,33 +14,7 @@ spec:
     singular: updateservice
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: The age of the UpdateService resource.
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: The external URI which exposes the policy engine.
-      jsonPath: .status.policyEngineURI
-      name: Policy Engine URI
-      priority: 1
-      type: string
-    - description: The repository in which release images are tagged.
-      jsonPath: .spec.releases
-      name: Releases
-      priority: 1
-      type: string
-    - description: The container image that contains the UpdateService graph data.
-      jsonPath: .spec.graphDataImage
-      name: Graph Data Image
-      priority: 1
-      type: string
-    - description: Status reports whether all required resources have been created
-        in the cluster and reflect the specified state.
-      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
-      name: Reconcile Completed
-      priority: 1
-      type: string
-    name: v1
+  - name: v1
     schema:
       openAPIV3Schema:
         description: UpdateService is the Schema for the updateservices API.
@@ -55,6 +29,8 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
+          metadata:
+            type: object
           spec:
             description: spec is the desired state of the UpdateService service.  The
               operator will work to ensure that the desired configuration is applied
@@ -111,25 +87,52 @@ spec:
                   - type
                   type: object
                 type: array
+              metadataURI:
+                description: "metadataURI is the external URI which exposes metadata.
+                  Available paths from this URI include: \n * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE},
+                  with release signatures."
+                type: string
               policyEngineURI:
                 description: "policyEngineURI is the external URI which exposes the
                   policy engine.  Available paths from this URI include: \n * /api/upgrades_info/v1/graph,
-                  with the update graph recommendations."
+                  with the update graph recommendations. * /api/upgrades_info/graph,
+                  with the update graph recommendations, versioned by content-type
+                  (e.g. application/vnd.redhat.cincinnati.v1+json)."
                 type: string
             required:
+            - metadataURI
             - policyEngineURI
             type: object
         required:
         - metadata
         - spec
         type: object
+    additionalPrinterColumns:
+    - name: Age
+      description: The age of the UpdateService resource.
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Policy Engine URI
+      description: The external URI which exposes the policy engine.
+      type: string
+      priority: 1
+      jsonPath: .status.policyEngineURI
+    - name: Releases
+      description: The repository in which release images are tagged.
+      type: string
+      priority: 1
+      jsonPath: .spec.releases
+    - name: Graph Data Image
+      description: The container image that contains the UpdateService graph data.
+      type: string
+      priority: 1
+      jsonPath: .spec.graphDataImage
+    - name: Reconcile Completed
+      description: Status reports whether all required resources have been created in the cluster and reflect the specified state.
+      type: string
+      priority: 1
+      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Generated with:

```console
$ cp config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
```

to catch up with 6b266d2707 (#173) suggests I could have done this with `make bundle VERSION=5.0.3-dev` or some such, but I don't have `operator-sdk` installed at the moment.