### PR TITLE
OTA-1014: controllers/updateservice_controller: Handle metadata container in ensureDeployment

### DIFF
--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -488,6 +488,8 @@ func (r *UpdateServiceReconciler) ensureDeployment(ctx context.Context, reqLogge
 			original = resources.graphBuilderContainer
 		case NameContainerPolicyEngine:
 			original = resources.policyEngineContainer
+		case NameContainerMetadata:
+			original = resources.metadataContainer
 		default:
 			reqLogger.Info("encountered unexpected container in pod", "Container.Name", containers[i].Name)
 			continue


### PR DESCRIPTION
Avoiding [`encountered unexpected container in pod` issues][1]:

```console
$ oc -n install-osus-here logs updateservice-operator-5bdfcff5c5-wqjdt|grep metadata|tail -n2
1.701074599173428e+09    INFO    controller_updateservice    Updating Service    {"Request.Namespace": "install-osus-here", "Request.Name": "sample", "Namespace": "install-osus-here", "Name": "sample-metadata"}
1.7010745992028923e+09    INFO    controller_updateservice    encountered unexpected container in pod    {"Request.Namespace": "install-osus-here", "Request.Name": "sample", "Container.Name": "metadata"}
```

which is also [seen][2] in [this CI run][3].

[1]: https://issues.redhat.com/browse/OTA-958?focusedId=23535225&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23535225
[2]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cincinnati-operator/176/pull-ci-openshift-cincinnati-operator-master-operator-e2e-hypershift-local-graph-data/1722333693256667136/artifacts/operator-e2e-hypershift-local-graph-data/e2e-test/artifacts/inspect/namespaces/openshift-updateservice/pods/updateservice-operator-55d95555b5-8cft9/updateservice-operator/updateservice-operator/logs/current.log
[3]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cincinnati-operator/176/pull-ci-openshift-cincinnati-operator-master-operator-e2e-hypershift-local-graph-data/1722333693256667136