### PR TITLE
Remove unnecessary env variables

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -603,15 +603,6 @@ func (k *kubeResources) newGraphBuilderContainer(instance *cv1.UpdateService, im
 		)
 	}
 
-	if k.trustedClusterCAConfig != nil {
-		gbENV = append(gbENV,
-			corev1.EnvVar{
-				Name:  "SSL_CERT_FILE",
-				Value: ClusterCAMountDir + NameClusterCertConfigMapKey,
-			},
-		)
-	}
-
 	g := &corev1.Container{
 		Name:            NameContainerGraphBuilder,
 		Image:           image,


### PR DESCRIPTION
this commit removes the SSL_CERT_FILE env variable as
we're programmatically adding SSL certs to requests
in cincinnati and no longer need this env variable
for CA certs to work.