### PR TITLE
OCPBUGS-33939: api/v1/updateservice_types: Explicit +kubebuilder:validation:Optional

### DIFF
--- a/api/v1/updateservice_types.go
+++ b/api/v1/updateservice_types.go
@@ -40,12 +40,14 @@ type UpdateServiceStatus struct {
 	//
 	// * /api/upgrades_info/v1/graph, with the update graph recommendations.
 	// * /api/upgrades_info/graph, with the update graph recommendations, versioned by content-type (e.g. application/vnd.redhat.cincinnati.v1+json).
+	// +kubebuilder:validation:Optional
 	PolicyEngineURI string `json:"policyEngineURI,optional"`
 
 	// metadataURI is the external URI which exposes metadata.
 	// Available paths from this URI include:
 	//
 	// * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE}, with release signatures.
+	// +kubebuilder:validation:Optional
 	MetadataURI string `json:"metadataURI,optional"`
 }
 

--- a/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
+++ b/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
@@ -99,9 +99,6 @@ spec:
                   with the update graph recommendations, versioned by content-type
                   (e.g. application/vnd.redhat.cincinnati.v1+json)."
                 type: string
-            required:
-            - metadataURI
-            - policyEngineURI
             type: object
         required:
         - metadata

--- a/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
+++ b/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
@@ -99,9 +99,6 @@ spec:
                   with the update graph recommendations, versioned by content-type
                   (e.g. application/vnd.redhat.cincinnati.v1+json)."
                 type: string
-            required:
-            - metadataURI
-            - policyEngineURI
             type: object
         required:
         - metadata


### PR DESCRIPTION
The Go-side 'optional' was not enough to get these optional, so talk to kubebuilder directly.  We need metadataURI to be optional to [avoid][1]:

```console
$ oc -n openshift-update-service get -o json installplan install-wpgw2 | jq '.status.conditions[]'
{
  "lastTransitionTime": "2024-05-20T07:05:46Z",
  "lastUpdateTime": "2024-05-20T07:05:46Z",
  "message": "error validating existing CRs against new CRD's schema for \"updateservices.updateservice.operator.openshift.io\": error validating updateservice.operator.openshift.io/v1, Kind=UpdateService \"openshift-update-service/sample\": updated validation is too restrictive: [].status.metadataURI: Required value",
  "reason": "InstallComponentFailed",
  "status": "False",
  "type": "Installed"
}
```

We need those existing 5.0.2 UpdateService to be compatible with the incoming 5.0.3 CustomResourceDefinition, so we can install the new CRD and updated operator, so the incoming operator can populate the new `metadataURI` property.

While I was fixing that property, I'm adding the same comment to `policyEngineURI` for consistency.  This will allow the operator do things like setting conditions complaining about difficulty provisioning the Route needed to figure out the `policyEngineURI`.

After updating the Go, I updated `config/crd/bases/...` like 6b266d2707 (#176):

```console
$ controller-gen rbac:roleName=updateservice-operator crd paths=./... output:crd:dir=config/crd/bases
$ git add -p  # preserve additionalPrinterColumns
```

using the same:

```console
$ controller-gen --version
Version: v0.13.0
```

I'd built in 6b266d2707 (there may have been subsequent releases; I haven't checked).  Then dropping the `additionalPrinterColumns` changes:

```console
$ git restore config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
```

And copying into the bundle as I'd done in e5716f8ebc (#179):

```console
$ cp config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
```

[1]: https://issues.redhat.com/browse/OCPBUGS-33939