### PR TITLE
Update hack/deploy.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Temporary Build Files
 build/_output
 build/_test
+# IDE folders
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,13 +17,20 @@ operator-sdk run --local
 The UpdateService graph data is loaded from an init container. Before deploying 
 the update-service-operator, you will need to [build and push an init container containing the graph data](docs/graph-data-init-container.md).
 
+## Build operator image
+
+```console
+podman build -f ./Dockerfile --platform=linux/amd64 -t your-registry/your-repo/your-update-service-operator:tag
+podman push your-registry/your-repo/your-update-service-operator:tag
+```
+
 ## Deploy operator
 
 ```
 make deploy
 ```
 
-By default, operator will be deployed using the default operator image `quay.io/updateservice/update-service-operator:latest`. If you want to override the default operator image with your image, set 
+By default, operator will be deployed using the default operator image `controller:latest`. If you want to override the default operator image with your image, set 
 
 ```
 export RELATED_IMAGE_OPERATOR="your-registry/your-repo/your-update-service-opertor-image:tag"

--- a/docs/graph-data-init-container.md
+++ b/docs/graph-data-init-container.md
@@ -20,8 +20,8 @@ When the init container runs, it untars the data to /var/lib/cincinnati/graph-da
 Build and push the image to your own repository. 
 
 ````
-podman build -f ./dev/Dockerfile -t quay.io/rwsu/cincinnati-graph-data-container:latest
-podman push quay.io/rwsu/cincinnati-graph-data-container:latest
+podman build -f ./dev/Dockerfile --platform=linux/amd64 -t your-registry/your-repo/your-cincinnati-graph-data-container:tag
+podman push your-registry/your-repo/your-cincinnati-graph-data-container:tag
 ````
 Depending upon your setup you need to make the repository public or private to make sure the operator can fetch the image from it.
 
@@ -41,5 +41,5 @@ metadata:
 spec:
   replicas: 1
   releases: quay.io/openshift-release-dev/ocp-release
-  graphDataImage: quay.io/rwsu/cincinnati-graph-data-container:latest
+  graphDataImage: your-registry/your-repo/your-cincinnati-graph-data-container:tag
 ```

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -21,9 +21,10 @@ fi
 
 echo "Deploying using ${RELATED_OPERATOR_IMAGE} as operator, ${RELATED_OPERAND_IMAGE} as operand and ${GRAPH_DATA_IMAGE} as graph data image"
 
-sed -i "s|$DEFAULT_OPERAND_IMAGE|$RELATED_OPERAND_IMAGE|" config/manager/manager.yaml
-sed -i "s|$DEFAULT_OPERATOR_IMAGE|$RELATED_OPERATOR_IMAGE|" config/manager/manager.yaml
-sed -i "s|your-registry/your-repo/your-init-container|$GRAPH_DATA_IMAGE|" config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml
+SED_CMD="${SED_CMD:-sed}"
+${SED_CMD} -i "s|$DEFAULT_OPERAND_IMAGE|$RELATED_OPERAND_IMAGE|" config/manager/manager.yaml
+${SED_CMD} -i "s|$DEFAULT_OPERATOR_IMAGE|$RELATED_OPERATOR_IMAGE|" config/manager/manager.yaml
+${SED_CMD} -i "s|your-registry/your-repo/your-init-container|$GRAPH_DATA_IMAGE|" config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml
 
 NAMESPACE="openshift-updateservice"
 oc create namespace $NAMESPACE


### PR DESCRIPTION
Update the steps to deploy the operator on a cluster.

- Add the steps to build and push the image as `quay.io/updateservice/update-service-operator:latest` is not public.
- Support to get `sed` command from an env. var. (friendly to mac users)
- Add `--platform=linux/amd64` in the `podman build` commands (friendly to mac users)

With the changes in this PR, I may deploy the operator on a cluster bot cluster by the following commands:

```console
$ SED_CMD=gsed RELATED_IMAGE_OPERATOR=quay.io/hongkliu/test:update-service-operator KUBECONFIG=/Users/hongkliu/Downloads/cluster-bot-2024-06-27-005539.kubeconfig.txt GRAPH_DATA_IMAGE=quay.io/hongkliu/test:cincinnati-graph-data-container make deploy

$ oc --kubeconfig ~/Downloads/cluster-bot-2024-06-27-005539.kubeconfig.txt get all -n openshift-updateservice
Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
NAME                                          READY   STATUS    RESTARTS   AGE
pod/updateservice-operator-767f57cbb6-pk5h7   1/1     Running   0          17s

NAME                                     TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
service/updateservice-operator-metrics   ClusterIP   172.30.100.142   <none>        8443/TCP   17s

NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/updateservice-operator   1/1     1            1           17s

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/updateservice-operator-767f57cbb6   1         1         1       17s
```