### PR TITLE
Bump kustomize version to 5.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,11 +85,7 @@ kustomize:
 ifeq (, $(shell which kustomize))
 	@{ \
 	set -e ;\
-	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
-	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
+	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s 5.4.2 $(GOBIN) ;\
 	}
 KUSTOMIZE=$(GOBIN)/kustomize
 else

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-08-09T15:46:12Z"
+    createdAt: "2024-06-28T02:54:06Z"
     description: Creates and maintains an OpenShift Update Service instance
     operatorframework.io/suggested-namespace: openshift-update-service
     operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp

--- a/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
+++ b/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
@@ -1,9 +1,9 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
+  creationTimestamp: null
   name: updateservices.updateservice.operator.openshift.io
 spec:
   group: updateservice.operator.openshift.io
@@ -14,7 +14,33 @@ spec:
     singular: updateservice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The age of the UpdateService resource.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The external URI which exposes the policy engine.
+      jsonPath: .status.policyEngineURI
+      name: Policy Engine URI
+      priority: 1
+      type: string
+    - description: The repository in which release images are tagged.
+      jsonPath: .spec.releases
+      name: Releases
+      priority: 1
+      type: string
+    - description: The container image that contains the UpdateService graph data.
+      jsonPath: .spec.graphDataImage
+      name: Graph Data Image
+      priority: 1
+      type: string
+    - description: Status reports whether all required resources have been created
+        in the cluster and reflect the specified state.
+      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
+      name: Reconcile Completed
+      priority: 1
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: UpdateService is the Schema for the updateservices API.
@@ -104,32 +130,13 @@ spec:
         - metadata
         - spec
         type: object
-    additionalPrinterColumns:
-    - name: Age
-      description: The age of the UpdateService resource.
-      type: date
-      jsonPath: .metadata.creationTimestamp
-    - name: Policy Engine URI
-      description: The external URI which exposes the policy engine.
-      type: string
-      priority: 1
-      jsonPath: .status.policyEngineURI
-    - name: Releases
-      description: The repository in which release images are tagged.
-      type: string
-      priority: 1
-      jsonPath: .spec.releases
-    - name: Graph Data Image
-      description: The container image that contains the UpdateService graph data.
-      type: string
-      priority: 1
-      jsonPath: .spec.graphDataImage
-    - name: Reconcile Completed
-      description: Status reports whether all required resources have been created in the cluster and reflect the specified state.
-      type: string
-      priority: 1
-      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
     served: true
     storage: true
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.5.4
vs
https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.4.2

The latest version (currently `v5.4.2`) supports more platforms.

Generated by:

```console
$ make bundle VERSION=5.0.2-dev

$ operator-sdk version
operator-sdk version: "v1.28.0-ocp", commit: "9faa5105bfa6ca52490a17dbaee0653dedd0e536", kubernetes version: "v1.26.0", go version: "go1.19.6", GOOS: "darwin", GOARCH: "arm64"

$ kustomize version
v5.4.2
```