### PR TITLE
Fix the metrics configuration

### DIFF
--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-28T02:54:06Z"
+    createdAt: "2024-06-28T14:03:37Z"
     description: Creates and maintains an OpenShift Update Service instance
     operatorframework.io/suggested-namespace: openshift-update-service
     operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp
@@ -190,11 +190,13 @@ spec:
           replicas: 1
           selector:
             matchLabels:
+              control-plane: updateservice-operator
               name: updateservice-operator
           strategy: {}
           template:
             metadata:
               labels:
+                control-plane: updateservice-operator
                 name: updateservice-operator
             spec:
               containers:

--- a/bundle/manifests/updateservice-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/updateservice-operator-metrics_v1_service.yaml
@@ -7,9 +7,9 @@ metadata:
   name: updateservice-operator-metrics
 spec:
   ports:
-  - name: https
-    port: 8443
-    targetPort: https
+  - name: metrics
+    port: 80
+    targetPort: 8080
   selector:
     control-plane: updateservice-operator
 status:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -7,10 +7,12 @@ spec:
   selector:
     matchLabels:
       name: updateservice-operator
+      control-plane: updateservice-operator
   template:
     metadata:
       labels:
         name: updateservice-operator
+        control-plane: updateservice-operator
     spec:
       serviceAccountName: updateservice-operator
       containers:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: openshift-updateservice
 spec:
   ports:
-  - name: https
-    port: 8443
-    targetPort: https
+  - name: metrics
+    port: 80
+    targetPort: 8080
   selector:
     control-plane: updateservice-operator

--- a/main.go
+++ b/main.go
@@ -27,13 +27,6 @@ import (
 	// +kubebuilder:scaffold:imports
 )
 
-// Change below variables to serve metrics on different host or port.
-var (
-	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
-)
-
 var (
 	scheme = apiruntime.NewScheme()
 	log    = ctrl.Log.WithName("cmd")


### PR DESCRIPTION
```console
$ oc --kubeconfig ~/Downloads/cluster-bot-2024-06-28-131404.kubeconfig.txt -n openshift-update-service exec updateservice-operator-6fb99ffc5f-dwp6m -- curl -s localhost:8080/metrics | head -n 1
# HELP certwatcher_read_certificate_errors_total Total number of certificate read errors

$ oc --kubeconfig ~/Downloads/cluster-bot-2024-06-28-131404.kubeconfig.txt -n openshift-update-service get pod --show-labels
NAME                                      READY   STATUS    RESTARTS   AGE   LABELS
updateservice-operator-6fb99ffc5f-dwp6m   1/1     Running   0          10m   name=updateservice-operator,pod-template-hash=6fb99ffc5f
```

- The port for metrics is `8080` (see the above command) which is aligned with the fault value. This PR fixes the port in the service accordingly.

https://github.com/openshift/cincinnati-operator/blob/e44857a46e222cd30eff7a43c1ffa652335d7d11/main.go#L68

- This PR adds the label from the service onto the deployment so that the service can proxy the pods of the deployment.