### PR TITLE
Fix a kustomize warning: 'bases' is deprecated

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namespace: openshift-updateservice
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- bases/update-service-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
```console
$ make bundle VERSION=5.0.2-dev
cd config/manager && /Users/hongkliu/go/bin/kustomize edit set image controller=controller:latest
/Users/hongkliu/go/bin/kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version 5.0.2-dev --channels=v1 --default-channel=v1
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesJson6902' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
INFO[0000] Creating bundle/metadata/annotations.yaml    
INFO[0000] Creating bundle.Dockerfile                   
INFO[0000] Bundle metadata generated successfully       
operator-sdk bundle validate ./bundle
INFO[0000] All validation tests have completed successfully 

```

This PR fixes the first warning "Warning: 'bases' is deprecated" from `kustomize`.
https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/bases/

The 2nd one about "patchesJson6902" is a bit involved. It is a much recent deprecation.
We may handle it in another PR.
https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/
