### PR TITLE
cincinnati-operator: bump operator-sdk versions to v1.31.0-ocp

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=update-service-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=v1
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v1
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0-ocp
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.31.0-ocp
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -16,14 +16,14 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-03T13:54:28Z"
+    createdAt: "2024-07-15T19:13:17Z"
     description: Creates and maintains an OpenShift Update Service instance
     kubernetes.io/description: "This OpenShift Update Service operator Deployment
       reconciles local UpdateServices into more fundamental Kubernetes\nand OpenShift
       resources like Cincinnati Deployments and Routes, and it reports the status
       of those components in \nthe UpdateService status.\n"
     operatorframework.io/suggested-namespace: openshift-update-service
-    operators.operatorframework.io/builder: operator-sdk-v1.28.0-ocp
+    operators.operatorframework.io/builder: operator-sdk-v1.31.0-ocp
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: update-service-operator.v5.0.2-dev
   namespace: placeholder

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: update-service-operator
   operators.operatorframework.io.bundle.channels.v1: v1
   operators.operatorframework.io.bundle.channel.default.v1: v1
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0-ocp
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.31.0-ocp
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
```console
$ podman run --platform=linux/amd64 --rm -it --entrypoint='["bash"]' registry.ci.openshift.org/origin/4.15:operator-sdk
bash-4.4$ operator-sdk version
operator-sdk version: "v1.31.0-ocp", commit: "08d08dd8e4da74c83fffa812fb8eb382eb0a072d", kubernetes version: "v1.26.0", go version: "go1.20.12 X:strictfipsruntime", GOOS: "linux", GOARCH: "amd64"
```

The [CI env.](https://github.com/openshift/release/blob/d6d69e0bf41d63f4e6848ac492498406116b4c31/ci-operator/config/openshift/cincinnati-operator/openshift-cincinnati-operator-master.yaml#L6-L9) has been moved forward and we might want to keep the version aligned with it. The manifests in bundles are [used only in CI or by QE](https://github.com/openshift/cincinnati-operator/pull/173) and thus should be safe enough to do.

The real reason that I want to bump the sdk version is that I am learning and do some practicing following the sdk doc.
Staying close with the latest version of sdk sometimes making the learning curve shorter.
