### PR TITLE
Fix manifests of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,6 @@ BUNDLE_DEFAULT_CHANNEL = --default-channel=$(DEFAULT_CHANNEL)
 
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -94,7 +91,7 @@ endif
 
 # Generate manifests e.g. CRD, RBAC etc.
 manifests:  controller-gen
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=updateservice-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=updateservice-operator webhook crd paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Generate bundle manifests
 gen-for-bundle: manifests kustomize

--- a/api/v1/updateservice_types.go
+++ b/api/v1/updateservice_types.go
@@ -64,7 +64,11 @@ const (
 )
 
 // +kubebuilder:object:root=true
-
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the UpdateService resource."
+// +kubebuilder:printcolumn:name="Policy Engine URI",type="string",JSONPath=".status.policyEngineURI",description="The external URI which exposes the policy engine.",priority=1
+// +kubebuilder:printcolumn:name="Releases",type="string",JSONPath=".spec.releases",description="The repository in which release images are tagged.",priority=1
+// +kubebuilder:printcolumn:name="Graph Data Image",type="string",JSONPath=".spec.graphDataImage",description="The container image that contains the UpdateService graph data.",priority=1
+// +kubebuilder:printcolumn:name="Reconcile Completed",type="string",JSONPath=`.status.conditions[?(@.type=="ReconcileCompleted")].status`,description="Status reports whether all required resources have been created in the cluster and reflect the specified state.",priority=1
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=updateservices,scope=Namespaced
 

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-15T19:13:17Z"
+    createdAt: "2024-07-16T12:47:34Z"
     description: Creates and maintains an OpenShift Update Service instance
     kubernetes.io/description: "This OpenShift Update Service operator Deployment
       reconciles local UpdateServices into more fundamental Kubernetes\nand OpenShift

--- a/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
+++ b/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
@@ -14,7 +14,33 @@ spec:
     singular: updateservice
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: The age of the UpdateService resource.
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: The external URI which exposes the policy engine.
+      jsonPath: .status.policyEngineURI
+      name: Policy Engine URI
+      priority: 1
+      type: string
+    - description: The repository in which release images are tagged.
+      jsonPath: .spec.releases
+      name: Releases
+      priority: 1
+      type: string
+    - description: The container image that contains the UpdateService graph data.
+      jsonPath: .spec.graphDataImage
+      name: Graph Data Image
+      priority: 1
+      type: string
+    - description: Status reports whether all required resources have been created
+        in the cluster and reflect the specified state.
+      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
+      name: Reconcile Completed
+      priority: 1
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: UpdateService is the Schema for the updateservices API.
@@ -104,31 +130,6 @@ spec:
         - metadata
         - spec
         type: object
-    additionalPrinterColumns:
-    - name: Age
-      description: The age of the UpdateService resource.
-      type: date
-      jsonPath: .metadata.creationTimestamp
-    - name: Policy Engine URI
-      description: The external URI which exposes the policy engine.
-      type: string
-      priority: 1
-      jsonPath: .status.policyEngineURI
-    - name: Releases
-      description: The repository in which release images are tagged.
-      type: string
-      priority: 1
-      jsonPath: .spec.releases
-    - name: Graph Data Image
-      description: The container image that contains the UpdateService graph data.
-      type: string
-      priority: 1
-      jsonPath: .spec.graphDataImage
-    - name: Reconcile Completed
-      description: Status reports whether all required resources have been created in the cluster and reflect the specified state.
-      type: string
-      priority: 1
-      jsonPath: .status.conditions[?(@.type=="ReconcileCompleted")].status
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
Generated by:

```console
$ make manifests
$ make bundle VERSION=5.0.2-dev
```

with

```
$ controller-gen --version
Version: v0.13.0

$ operator-sdk version    
operator-sdk version: "v1.31.0-ocp", commit: "23376a866e765de8e097859b0b917cdb75fdc2b0", kubernetes version: "v1.26.0", go version: "go1.20.12", GOOS: "darwin", GOARCH: "arm64"

$ go version
go version go1.21.1 darwin/arm64
```

- Removed `CRD_OPTIONS` which does not work with `controller-gen` of `v0.13.0`. The version has been used already since https://github.com/openshift/cincinnati-operator/commit/6b266d27077096317338733693da0768a31e9b3e of https://github.com/openshift/cincinnati-operator/pull/176 There the `controller-gen` cmd has the `crd` as an arg already.
- Added  markers like `+kubebuilder:printcolumn` to let `controller-gen` [generate](https://book.kubebuilder.io/reference/generating-crd.html?highlight=AdditionalPrinterColumns#additional-printer-columns) `additionalPrinterColumns` automatically instead of `git add -p` in the above commit.
