### PR TITLE
Rerun operator-sdk generate kustomize manifests

### DIFF
--- a/api/v1/updateservice_types.go
+++ b/api/v1/updateservice_types.go
@@ -14,16 +14,19 @@ type UpdateServiceSpec struct {
 	// all times.
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Replicas int32 `json:"replicas"`
 
 	// releases is the repository in which release images are tagged,
 	// such as quay.io/openshift-release-dev/ocp-release.
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Releases string `json:"releases"`
 
 	// graphDataImage is a container image that contains the UpdateService graph
 	// data.
 	// +kubebuilder:validation:Required
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	GraphDataImage string `json:"graphDataImage"`
 }
 
@@ -33,6 +36,7 @@ type UpdateServiceStatus struct {
 	// +patchMergeKey=type
 	// +patchStrategy=merge
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
 	Conditions []conditionsv1.Condition `json:"conditions,omitempty"  patchStrategy:"merge" patchMergeKey:"type"`
 
 	// policyEngineURI is the external URI which exposes the policy
@@ -41,6 +45,7 @@ type UpdateServiceStatus struct {
 	// * /api/upgrades_info/v1/graph, with the update graph recommendations.
 	// * /api/upgrades_info/graph, with the update graph recommendations, versioned by content-type (e.g. application/vnd.redhat.cincinnati.v1+json).
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
 	PolicyEngineURI string `json:"policyEngineURI,optional"`
 
 	// metadataURI is the external URI which exposes metadata.
@@ -48,6 +53,7 @@ type UpdateServiceStatus struct {
 	//
 	// * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE}, with release signatures.
 	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
 	MetadataURI string `json:"metadataURI,optional"`
 }
 
@@ -63,6 +69,7 @@ const (
 	ConditionReconcileError conditionsv1.ConditionType = "ReconcileError"
 )
 
+// +operator-sdk:csv:customresourcedefinitions:resources={{Service,v1,policy-engine-service}}
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="The age of the UpdateService resource."
 // +kubebuilder:printcolumn:name="Policy Engine URI",type="string",JSONPath=".status.policyEngineURI",description="The external URI which exposes the policy engine.",priority=1

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-16T12:47:34Z"
+    createdAt: "2024-07-18T00:26:47Z"
     description: Creates and maintains an OpenShift Update Service instance
     kubernetes.io/description: "This OpenShift Update Service operator Deployment
       reconciles local UpdateServices into more fundamental Kubernetes\nand OpenShift
@@ -37,12 +37,37 @@ spec:
       name: updateservices.updateservice.operator.openshift.io
       resources:
       - kind: Service
-        name: ""
-        version: ""
+        name: policy-engine-service
+        version: v1
       specDescriptors:
-      - path: replicas
+      - description: graphDataImage is a container image that contains the UpdateService
+          graph data.
+        displayName: Graph Data Image
+        path: graphDataImage
+      - description: releases is the repository in which release images are tagged,
+          such as quay.io/openshift-release-dev/ocp-release.
+        displayName: Releases
+        path: releases
+      - description: replicas is the number of pods to run. When >=2, a PodDisruptionBudget
+          will ensure that voluntary disruption leaves at least one Pod running at
+          all times.
+        displayName: Replicas
+        path: replicas
       statusDescriptors:
-      - path: replicas
+      - description: Conditions describe the state of the UpdateService resource.
+        displayName: Conditions
+        path: conditions
+      - description: "metadataURI is the external URI which exposes metadata. Available
+          paths from this URI include: \n * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE},
+          with release signatures."
+        displayName: Metadata URI
+        path: metadataURI
+      - description: "policyEngineURI is the external URI which exposes the policy
+          engine.  Available paths from this URI include: \n * /api/upgrades_info/v1/graph,
+          with the update graph recommendations. * /api/upgrades_info/graph, with
+          the update graph recommendations, versioned by content-type (e.g. application/vnd.redhat.cincinnati.v1+json)."
+        displayName: Policy Engine URI
+        path: policyEngineURI
       version: v1
   description: |-
     # Use Case

--- a/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
@@ -2,20 +2,17 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    # This description annotation is here because
-    # it is a workaround of annotating the deployment which is currently not taken into the CSV
-    # https://github.com/operator-framework/api/pull/350#issuecomment-2204202612
-    kubernetes.io/description: |
-      This OpenShift Update Service operator Deployment reconciles local UpdateServices into more fundamental Kubernetes
-      and OpenShift resources like Cincinnati Deployments and Routes, and it reports the status of those components in 
-      the UpdateService status.
     alm-examples: '[]'
     capabilities: Basic Install
     description: Creates and maintains an OpenShift Update Service instance
+    kubernetes.io/description: "This OpenShift Update Service operator Deployment
+      reconciles local UpdateServices into more fundamental Kubernetes\nand OpenShift
+      resources like Cincinnati Deployments and Routes, and it reports the status
+      of those components in \nthe UpdateService status.\n"
     operatorframework.io/suggested-namespace: openshift-update-service
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: update-service-operator.vX.Y.Z
+  name: update-service-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -25,13 +22,40 @@ spec:
       displayName: Update Service
       kind: UpdateService
       name: updateservices.updateservice.operator.openshift.io
-      version: v1
       resources:
       - kind: Service
+        name: policy-engine-service
+        version: v1
       specDescriptors:
-      - path: replicas
+      - description: graphDataImage is a container image that contains the UpdateService
+          graph data.
+        displayName: Graph Data Image
+        path: graphDataImage
+      - description: releases is the repository in which release images are tagged,
+          such as quay.io/openshift-release-dev/ocp-release.
+        displayName: Releases
+        path: releases
+      - description: replicas is the number of pods to run. When >=2, a PodDisruptionBudget
+          will ensure that voluntary disruption leaves at least one Pod running at
+          all times.
+        displayName: Replicas
+        path: replicas
       statusDescriptors:
-      - path: replicas
+      - description: Conditions describe the state of the UpdateService resource.
+        displayName: Conditions
+        path: conditions
+      - description: "metadataURI is the external URI which exposes metadata. Available
+          paths from this URI include: \n * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE},
+          with release signatures."
+        displayName: Metadata URI
+        path: metadataURI
+      - description: "policyEngineURI is the external URI which exposes the policy
+          engine.  Available paths from this URI include: \n * /api/upgrades_info/v1/graph,
+          with the update graph recommendations. * /api/upgrades_info/graph, with
+          the update graph recommendations, versioned by content-type (e.g. application/vnd.redhat.cincinnati.v1+json)."
+        displayName: Policy Engine URI
+        path: policyEngineURI
+      version: v1
   description: |-
     # Use Case
     Running an Update Service instance in a cluster is appealing for offline OpenShift


### PR DESCRIPTION
This PR is generated by

```console
$ ./bin/operator-sdk version                        
operator-sdk version: "v1.31.0-ocp", commit: "23376a866e765de8e097859b0b917cdb75fdc2b0", kubernetes version: "v1.26.0", go version: "go1.20.12", GOOS: "darwin", GOARCH: "arm64"

$ operator-sdk generate kustomize manifests -q
$ make bundle VERSION=5.0.2-dev
```

It turns out that `config/manifests/bases/update-service-operator.clusterserviceversion.yaml` is also generated (by `operator-sdk generate kustomize manifests -q`).
It copies the `kubernetes.io/description` annotation over from the `config/manager/manager.yaml` that is exactly we did manually.
