### PR TITLE
Add verify-generate in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,25 +73,41 @@ LOCALBIN ?= $(shell pwd)/bin
 $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+KUSTOMIZE_VERSION ?= 5.2.1
 CONTROLLER_TOOLS_VERSION ?= v0.13.0
+OPERATOR_SDK_VERSION ?= v1.31.0-ocp
 
 .PHONY: controller-gen
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
 	GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
-kustomize:
-ifeq (, $(shell which kustomize))
-	@{ \
-	set -e ;\
-	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s 5.4.2 $(LOCALBIN) ;\
-	}
-KUSTOMIZE=$(LOCALBIN)/kustomize
-else
-KUSTOMIZE=$(shell which kustomize)
-endif
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
+$(KUSTOMIZE): $(LOCALBIN)
+	@if test -x $(LOCALBIN)/kustomize && ! $(LOCALBIN)/kustomize version | grep -q v$(KUSTOMIZE_VERSION); then \
+		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
+		rm -rf $(LOCALBIN)/kustomize; \
+	fi
+	test -s $(LOCALBIN)/kustomize || curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s $(KUSTOMIZE_VERSION) $(LOCALBIN)
+
+
+.PHONY: operator-sdk
+OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
+OPERATOR_SDK_URL ?= https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.15.21/operator-sdk-v1.31.0-ocp-linux-x86_64.tar.gz
+###for mac arm64 users:
+###OPERATOR_SDK_URL ?= https://mirror.openshift.com/pub/openshift-v4/arm64/clients/operator-sdk/4.15.21/operator-sdk-v1.31.0-ocp-darwin-aarch64.tar.gz
+operator-sdk: $(OPERATOR_SDK)
+$(OPERATOR_SDK): $(LOCALBIN)
+	@if test -x $(LOCALBIN)/operator-sdk && ! $(LOCALBIN)/operator-sdk version | grep -q $(OPERATOR_SDK_VERSION); then \
+		echo "$(LOCALBIN)/operator-sdk version is not expected $(OPERATOR_SDK_VERSION). Removing it before installing."; \
+		rm -rf $(LOCALBIN)/operator-sdk; \
+	fi
+	test -s $(LOCALBIN)/operator-sdk || (curl -Lso /tmp/operator-sdk.tar.gz $(OPERATOR_SDK_URL) && tar -vxzf /tmp/operator-sdk.tar.gz --strip=2 -C $(LOCALBIN))
+
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests
@@ -110,16 +126,23 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-# Generate bundle manifests
-gen-for-bundle: manifests kustomize
-	operator-sdk generate kustomize manifests -q
 
-# Generate bundle and metadata, then validate generated files.
-bundle: kustomize
+# BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
+BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+
+.PHONY: bundle
+bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle $(BUNDLE_GEN_FLAGS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 # Build the bundle image.
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+
+.PHONY: verify-generate
+verify-generate: manifests generate fmt vet
+	$(MAKE) bundle VERSION=$(VERSION)
+	git diff --exit-code -I"createdAt:"

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-07-18T00:26:47Z"
+    createdAt: "2024-07-18T19:55:07Z"
     description: Creates and maintains an OpenShift Update Service instance
     kubernetes.io/description: "This OpenShift Update Service operator Deployment
       reconciles local UpdateServices into more fundamental Kubernetes\nand OpenShift


### PR DESCRIPTION
- Download the tools such as `kustomize` and `operator-sdk` on the fly, like [the operator sdk's example](https://github.com/operator-framework/operator-sdk/blob/e95abdbd5ccb7ca0fd586e0c6f578e491b0a025b/testdata/go/v4/memcached-operator/Makefile#L220). We will use them in CI.
- The existing target `bundle` is aligned with [the operator sdk's example](https://github.com/operator-framework/operator-sdk/blob/e95abdbd5ccb7ca0fd586e0c6f578e491b0a025b/testdata/go/v4/memcached-operator/Makefile#L257).
- The new target `pull-ci-openshift-cincinnati-operator-master-verify-generate` will be used by the job from https://github.com/openshift/release/pull/54417