### PR TITLE
Rename VERSION to OPERATOR_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
 WORKDIR /go/src/github.com/openshift/cincinnati-operator/
 COPY . .
-RUN make GOBUILDFLAGS=-mod=vendor VERSION="$(git describe --abbrev=8 --dirty --always)" build
+RUN make GOBUILDFLAGS=-mod=vendor OPERATOR_VERSION="$(git describe --abbrev=8 --dirty --always)" build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Current Operator version
-VERSION ?= 5.0.3-dev
+OPERATOR_VERSION ?= 5.0.3-dev
 
 .PHONY: \
 	clean \
@@ -15,7 +15,7 @@ VERSION ?= 5.0.3-dev
 ARTIFACT_DIR ?= .
 SOURCES := $(shell find . -name '*.go' -not -path "*/vendor/*")
 GOBUILDFLAGS ?= -i -mod=vendor
-GOLDFLAGS ?= -s -w -X github.com/openshift/cincinnati-operator/version.Operator=$(VERSION)
+GOLDFLAGS ?= -s -w -X github.com/openshift/cincinnati-operator/version.Operator=$(OPERATOR_VERSION)
 
 # This is a placeholder for cincinnati-operator image placeholder
 # During development override this when you want to use an specific image
@@ -128,7 +128,7 @@ vet: ## Run go vet against code.
 
 
 # BUNDLE_GEN_FLAGS are the flags passed to the operator-sdk generate bundle command
-BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+BUNDLE_GEN_FLAGS ?= -q --overwrite --version $(OPERATOR_VERSION) $(BUNDLE_METADATA_OPTS)
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
@@ -143,7 +143,7 @@ bundle-build:
 
 .PHONY: verify-generate
 verify-generate: manifests generate fmt vet
-	$(MAKE) bundle VERSION=$(VERSION)
+	$(MAKE) bundle OPERATOR_VERSION=$(OPERATOR_VERSION)
 	git diff --exit-code -I"createdAt:"
 
 

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ make unit-test
 ## Generating OLM manifests
 
 Here are the steps to generate the operator-framework manifests in the bundle format
-* Set the `VERSION` value in the shell
+* Set the `OPERATOR_VERSION` value in the shell
 * Set the `IMG` value pointing to the OSUS operator which should be part of the operator bundle.
 * Run `make bundle`.
 
 Example:
 
 ```sh
-VERSION=4.9.0
+OPERATOR_VERSION=4.9.0
 IMG=registry.com/cincinnati-openshift-update-service-operator:v4.6.0
 make bundle
 ```


### PR DESCRIPTION
To follow up https://github.com/openshift/release/pull/54417#discussion_r1695091333

VERSION is defined by our root image:

```console
podman run -it --rm registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15
WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)
[root@02c6f2b07fcc origin]# echo $VERSION
1.20
```

This renaming would avoid the variable value from being inherited by make targets.