### PR TITLE
functests: increase 10m to wait for deployment to be ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 func-test: deploy
 	@echo "Running functional test suite"
 	go clean -testcache
-	go test -timeout 20m -v ./functests/... || (oc -n openshift-update-service adm inspect --dest-dir="$(ARTIFACT_DIR)/inspect" namespace/openshift-update-service customresourcedefinition/updateservices.updateservice.operator.openshift.io updateservice/example; false)
+	go test -timeout 30m -v ./functests/... || (oc -n openshift-update-service adm inspect --dest-dir="$(ARTIFACT_DIR)/inspect" namespace/openshift-update-service customresourcedefinition/updateservices.updateservice.operator.openshift.io updateservice/example; false)
 
 unit-test:
 	@echo "Executing unit tests"

--- a/functests/utils.go
+++ b/functests/utils.go
@@ -27,7 +27,7 @@ const (
 	resource           = "updateservices"
 	replicas           = 1
 	retryInterval      = time.Second * 30
-	timeout            = time.Second * 600
+	timeout            = time.Minute * 20
 )
 
 // getConfig is the function used to retrieve the kubernetes config


### PR DESCRIPTION
It took over 10m in the last successful run: `12m`

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cincinnati-operator/227/pull-ci-openshift-cincinnati-operator-master-operator-e2e-new-ocp-published-graph-data/1912692491069427712/artifacts/operator-e2e-new-ocp-published-graph-data/e2e-test/build-log.txt | rg 'Dep.*ava|example created'
I0417 02:30:19.606998    9932 utils.go:113] Deployment updateservice-operator available (1/1)
I0417 02:30:21.224743    9932 utils.go:86] updateservice.updateservice.operator.openshift.io/example created
I0417 02:42:21.266104    9932 utils.go:113] Deployment example available (1/1)
```

This one is taken from [the job for this RP](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cincinnati-operator/227/pull-ci-openshift-cincinnati-operator-master-operator-e2e-new-ocp-published-graph-data/1912837069097406464): `15m`

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cincinnati-operator/227/pull-ci-openshift-cincinnati-operator-master-operator-e2e-new-ocp-published-graph-data/1912837069097406464/artifacts/operator-e2e-new-ocp-published-graph-data/e2e-test/build-log.txt | rg 'Dep.*ava|example created'
I0417 12:11:55.945638    9847 utils.go:113] Deployment updateservice-operator available (1/1)
I0417 12:11:57.552971    9847 utils.go:86] updateservice.updateservice.operator.openshift.io/example created
I0417 12:26:57.604667    9847 utils.go:113] Deployment example available (1/1)
```