### PR TITLE
OTA-1491: Bump base image to ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/cincinnati-operator/
 COPY . .
 RUN make GOBUILDFLAGS=-mod=vendor OPERATOR_VERSION="$(git describe --abbrev=8 --dirty --always)" build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /go/src/github.com/openshift/cincinnati-operator/update-service-operator /usr/bin/update-service-operator
 ENTRYPOINT ["/usr/bin/update-service-operator"]


### PR DESCRIPTION
UBI9 has a wider range of FIPS-support of OpenShift and Host Operating System than UBI8 [1].

[1]. https://docs.google.com/document/d/1CTpSwITQfOgoOTlPITZNJZy0ltYz60hxkmWsLemCqw0/edit?usp=sharing