### PR TITLE
OTA-1517: Scrape a smaller release repo in func-e2e

### DIFF
--- a/config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml
+++ b/config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml
@@ -4,5 +4,5 @@ metadata:
   name: example
 spec:
   replicas: 1
-  releases: quay.io/openshift-release-dev/ocp-release
+  releases: quay.io/redhat/openshift-cincinnati-test-public-manual
   graphDataImage: your-registry/your-repo/your-init-container


### PR DESCRIPTION
The file `config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml`
is used only in func-test.
```console
$ rg v1_updateservice_cr
functests/utils.go
81:     cmd := exec.CommandContext(ctx, "oc", "apply", "-f", "../config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml", "-n", operatorNamespace)

hack/kustomize_edit_env_vars.sh
31:${SED_CMD} -i "s|your-registry/your-repo/your-init-container|$GRAPH_DATA_IMAGE|" config/samples/updateservice.operator.openshift.io_v1_updateservice_cr.yaml
```

`kustomize_edit_env_vars` above is used as a prep for e2e.

The `releases` in the updateservice's sepc is changed to "quay.io/redhat/openshift-cincinnati-test-public-manual" ([having 2 tags](https://quay.io/repository/redhat/openshift-cincinnati-test-public-manual?tab=tags) at the moment.)
to avoid the load caused by scaping the release repo in production.

`quay.io/redhat/openshift-cincinnati-test-public-manual` is taken from [here](https://github.com/openshift/cincinnati?tab=readme-ov-file#executables-on-the-build-host).
No e2e is broken at the moment. So the tags in the repo seems not relevant.


In [this job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cincinnati-operator/234/pull-ci-openshift-cincinnati-operator-master-operator-e2e-new-ocp-published-graph-data/1920181236198805504) the deployment became ready in `3.5m`, much faster (than [this](https://github.com/openshift/cincinnati-operator/pull/227#issuecomment-2824840419)) as expected.


