### PR TITLE
Remove metadata-helper

### DIFF
--- a/api/v1/updateservice_types.go
+++ b/api/v1/updateservice_types.go
@@ -47,14 +47,6 @@ type UpdateServiceStatus struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	PolicyEngineURI string `json:"policyEngineURI,optional"`
-
-	// metadataURI is the external URI which exposes metadata.
-	// Available paths from this URI include:
-	//
-	// * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE}, with release signatures.
-	// +kubebuilder:validation:Optional
-	// +operator-sdk:csv:customresourcedefinitions:type=status
-	MetadataURI string `json:"metadataURI,optional"`
 }
 
 // Condition Types

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-16T14:22:33Z"
+    createdAt: "2025-05-14T21:01:52Z"
     description: Creates and maintains an OpenShift Update Service instance
     kubernetes.io/description: "This OpenShift Update Service operator Deployment
       reconciles local UpdateServices into more fundamental Kubernetes\nand OpenShift
@@ -57,11 +57,6 @@ spec:
       - description: Conditions describe the state of the UpdateService resource.
         displayName: Conditions
         path: conditions
-      - description: "metadataURI is the external URI which exposes metadata. Available
-          paths from this URI include: \n * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE},
-          with release signatures."
-        displayName: Metadata URI
-        path: metadataURI
       - description: "policyEngineURI is the external URI which exposes the policy
           engine.  Available paths from this URI include: \n * /api/upgrades_info/v1/graph,
           with the update graph recommendations. * /api/upgrades_info/graph, with

--- a/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
+++ b/bundle/manifests/updateservice.operator.openshift.io_updateservices.yaml
@@ -124,14 +124,6 @@ spec:
                   - type
                   type: object
                 type: array
-              metadataURI:
-                description: |-
-                  metadataURI is the external URI which exposes metadata.
-                  Available paths from this URI include:
-
-
-                  * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE}, with release signatures.
-                type: string
               policyEngineURI:
                 description: |-
                   policyEngineURI is the external URI which exposes the policy

--- a/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
+++ b/config/crd/bases/updateservice.operator.openshift.io_updateservices.yaml
@@ -124,14 +124,6 @@ spec:
                   - type
                   type: object
                 type: array
-              metadataURI:
-                description: |-
-                  metadataURI is the external URI which exposes metadata.
-                  Available paths from this URI include:
-
-
-                  * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE}, with release signatures.
-                type: string
               policyEngineURI:
                 description: |-
                   policyEngineURI is the external URI which exposes the policy

--- a/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/update-service-operator.clusterserviceversion.yaml
@@ -44,11 +44,6 @@ spec:
       - description: Conditions describe the state of the UpdateService resource.
         displayName: Conditions
         path: conditions
-      - description: "metadataURI is the external URI which exposes metadata. Available
-          paths from this URI include: \n * /api/upgrades_info/signatures/{ALGORITHM}/{DIGEST}/{SIGNATURE},
-          with release signatures."
-        displayName: Metadata URI
-        path: metadataURI
       - description: "policyEngineURI is the external URI which exposes the policy
           engine.  Available paths from this URI include: \n * /api/upgrades_info/v1/graph,
           with the update graph recommendations. * /api/upgrades_info/graph, with

--- a/controllers/names.go
+++ b/controllers/names.go
@@ -10,8 +10,6 @@ const (
 	NameContainerGraphBuilder string = "graph-builder"
 	// NameContainerPolicyEngine is the Name property of the policy engine container
 	NameContainerPolicyEngine string = "policy-engine"
-	// NameContainerMetadata is the Name property of the metadata container
-	NameContainerMetadata string = "metadata"
 	// NameInitContainerGraphData is the Name property of the graph data container
 	NameInitContainerGraphData string = "graph-data"
 	// OpenshiftConfigNamespace is the name of openshift's configuration namespace
@@ -50,10 +48,6 @@ func namePolicyEngineService(instance *cv1.UpdateService) string {
 	return instance.Name + "-policy-engine"
 }
 
-func nameMetadataService(instance *cv1.UpdateService) string {
-	return instance.Name + "-metadata"
-}
-
 func nameGraphBuilderService(instance *cv1.UpdateService) string {
 	return instance.Name + "-graph-builder"
 }
@@ -64,10 +58,6 @@ func namePolicyEngineRoute(instance *cv1.UpdateService) string {
 
 func oldPolicyEngineRouteName(instance *cv1.UpdateService) string {
 	return namePolicyEngineService(instance) + "-route"
-}
-
-func nameMetadataRoute(instance *cv1.UpdateService) string {
-	return instance.Name + "-meta-route"
 }
 
 func nameAdditionalTrustedCA(instance *cv1.UpdateService) string {

--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -163,10 +163,8 @@ func (r *UpdateServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.ensureAdditionalTrustedCA,
 		r.ensureGraphBuilderService,
 		r.ensurePolicyEngineService,
-		r.ensureMetadataService,
 		r.ensurePodDisruptionBudget,
 		r.ensurePolicyEngineRoute,
-		r.ensureMetadataRoute,
 	} {
 		err = f(ctx, reqLogger, instanceCopy, resources)
 		if err != nil {
@@ -490,8 +488,6 @@ func (r *UpdateServiceReconciler) ensureDeployment(ctx context.Context, reqLogge
 			original = resources.graphBuilderContainer
 		case NameContainerPolicyEngine:
 			original = resources.policyEngineContainer
-		case NameContainerMetadata:
-			original = resources.metadataContainer
 		default:
 			reqLogger.Info("encountered unexpected container in pod", "Container.Name", containers[i].Name)
 			continue
@@ -644,20 +640,6 @@ func (r *UpdateServiceReconciler) ensureGraphBuilderService(ctx context.Context,
 	return nil
 }
 
-func (r *UpdateServiceReconciler) ensureMetadataService(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
-	service := resources.metadataService
-	// Set UpdateService instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, service, r.Scheme); err != nil {
-		return err
-	}
-
-	if err := r.ensureService(ctx, reqLogger, service); err != nil {
-		handleErr(reqLogger, &instance.Status, "EnsureServiceFailed", err)
-		return err
-	}
-	return nil
-}
-
 func (r *UpdateServiceReconciler) ensurePolicyEngineService(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
 	service := resources.policyEngineService
 	// Set UpdateService instance as the owner and controller
@@ -692,53 +674,6 @@ func validateRouteName(instance *cv1.UpdateService, name string, namespace strin
 		return fmt.Errorf(fmt.Sprintf("UpdateService route name %q %s", routeName, errReasons[0]))
 	}
 	return fmt.Errorf(fmt.Sprintf("UpdateService route name %q %s Route name %s", routeName, errReasons[0], errReasons[1]))
-}
-
-func (r *UpdateServiceReconciler) ensureMetadataRoute(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
-	route := resources.metadataRoute
-	foundRoute := &routev1.Route{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, foundRoute)
-	if err != nil && apiErrors.IsNotFound(err) {
-		// Set UpdateService instance as the owner and controller
-		if err = controllerutil.SetControllerReference(instance, route, r.Scheme); err != nil {
-			return err
-		}
-		reqLogger.Info("Creating Route", "Namespace", route.Namespace, "Name", route.Name)
-		if err = r.Client.Create(ctx, route); err != nil {
-			handleErr(reqLogger, &instance.Status, "CreateRouteFailed", err)
-		}
-		return err
-	} else if err != nil {
-		handleErr(reqLogger, &instance.Status, "GetRouteFailed", err)
-		return err
-	}
-
-	if uri, _, err := routeapihelpers.IngressURI(foundRoute, ""); err == nil {
-		instance.Status.MetadataURI = uri.String()
-	} else {
-		handleErr(reqLogger, &instance.Status, "RouteIngressFailed", err)
-	}
-
-	updated := foundRoute.DeepCopy()
-	// Keep found tls for later use
-	tls := updated.Spec.TLS
-	// This is just so we compare the Spec on the two objects but make an exception for Spec.TLS
-	updated.Spec.TLS = route.Spec.TLS
-
-	// found existing resource; let's compare and update if needed
-	if !reflect.DeepEqual(updated.Spec, route.Spec) {
-		reqLogger.Info("Updating Route", "Namespace", route.Namespace, "Name", route.Name)
-		updated.Spec = route.Spec
-		// We want to allow user to update the TLS cert/key manually on the route and we don't want to override that change.
-		// Keep the existing tls on the route
-		updated.Spec.TLS = tls
-		err = r.Client.Update(ctx, updated)
-		if err != nil {
-			handleErr(reqLogger, &instance.Status, "UpdateRouteFailed", err)
-		}
-	}
-
-	return nil
 }
 
 func (r *UpdateServiceReconciler) ensurePolicyEngineRoute(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -4,6 +4,4 @@ RUN curl -L -o cincinnati-graph-data.tar.gz https://api.openshift.com/api/upgrad
 
 RUN mkdir -p /var/lib/cincinnati-graph-data && tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati-graph-data/ --no-overwrite-dir --no-same-owner
 
-RUN mkdir -p /var/lib/cincinnati-graph-data/signatures/sha256/beda83fb057e328d6f94f8415382350ca3ddf99bb9094e262184e0f127810ce0 && curl -L https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/sha256=beda83fb057e328d6f94f8415382350ca3ddf99bb9094e262184e0f127810ce0/signature-1 >/var/lib/cincinnati-graph-data/signatures/sha256/beda83fb057e328d6f94f8415382350ca3ddf99bb9094e262184e0f127810ce0/signature-1 && echo 1.2.0 >/var/lib/cincinnati-graph-data/version
-
 CMD ["/bin/bash", "-c" ,"exec cp -rpv /var/lib/cincinnati-graph-data/* /var/lib/cincinnati/graph-data"]


### PR DESCRIPTION
Follow up [the Slack discussion](https://redhat-internal.slack.com/archives/CJ1J9C3V4/p1746204277175029?thread_ts=1746200201.982019&cid=CJ1J9C3V4).

Remove metadata-helper from the cincinnati-operator.
Practically, the last 3 commits from https://github.com/openshift/cincinnati-operator/pull/176/commits are reverted by this PR.

Is it OK if we just remove an existing API like [UpdateService.status.MetadataURI](https://github.com/openshift/cincinnati-operator/compare/master...hongkailiu:cincinnati-operator:rm-metadata-helper?expand=1#diff-9a932dc9a2e3a1f3c1dda661968d210b80b06436b01883233b3035c75c2562d4L57)?

I am not sure if any user will use that field in their automation which may collapse if the field disappears?

The bright part is that the field is in status which means it should be readonly field for normal users. 
