### PR TITLE
Operator creates cluster-trusted-ca configmap only when proxy variables are set

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -512,16 +512,6 @@ func (k *kubeResources) newTrustedCAConfig(instance *cv1.UpdateService, cm *core
 
 func newTrustedClusterCAConfig(instance *cv1.UpdateService, clusterCA *corev1.ConfigMap) *corev1.ConfigMap {
 
-	// check if the proxy variables are set by olm
-	httpProxy := os.Getenv("HTTP_PROXY")
-	httpsProxy := os.Getenv("HTTPS_PROXY")
-	noProxy := os.Getenv("NO_PROXY")
-
-	if httpProxy == "" && httpsProxy == "" && noProxy == "" {
-		// cluster wide proxy is not set, so dont create configmap
-		return nil
-	}
-
 	if clusterCA != nil {
 		return clusterCA
 	}

--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -281,7 +281,7 @@ func (r *UpdateServiceReconciler) findTrustedCAConfig(ctx context.Context, reqLo
 	return sourceCM, nil
 }
 
-// findTrustedCAConfig - Locate the ConfigMap referenced by the ImageConfig resource in openshift-config and return it
+// findTrustedCAConfig - Locate the ConfigMap referenced by the trustedCA from Proxy resource in openshift-config and return it
 func (r *UpdateServiceReconciler) findTrustedClusterCAConfig(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService) (*corev1.ConfigMap, error) {
 
 	// Search for the ConfigMap in the operator namespace


### PR DESCRIPTION
Hello, 

The OSUS operator is checking if proxy variables are set before deciding if the cluster-trusted-ca configmap should be created or not with the cluster trusted CA bundle. It should not checked considering using this method as proxy variables don't have any relation with cluster's certificates, but on how the applications are going to access external resources. 

In some setups, the proxy variables are not set and the registries are installed using public default CAs as root CA. In this kind of setups, the OSUS pods don't start properly because the root CAs are not imported into pod. If the public root CA is configured in image.config CR, it workarounds the issue.

Note that when no <>-trusted-ca configmap is available, the trusted CA bundle is installed on /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem. However, when image.config is configured, the certificates from configmap overwritten this configuration. If no proxies are set, no trusted bundle are present in the pod.

I would like to recommend your revision on this PR. Feel free to change or recommend anything. 