### PR TITLE
OTA-1610: restrict OSUS egress to registry and proxy ports

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -4,8 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -303,13 +306,85 @@ func (k *kubeResources) oldPolicyEngineRoute(instance *cv1.UpdateService) *route
 	}
 }
 
+func egressPorts(releases string) []int32 {
+	seen := map[int32]bool{}
+	var ports []int32
+	add := func(p int32) {
+		if !seen[p] {
+			seen[p] = true
+			ports = append(ports, p)
+		}
+	}
+
+	registry := strings.SplitN(releases, "/", 2)[0]
+	registryPort := portFromHost(registry, 443)
+	add(registryPort)
+
+	if !isClusterInternal(registry) {
+		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY"} {
+			if v := os.Getenv(env); v != "" {
+				add(portFromProxyURL(v))
+			}
+		}
+	}
+
+	return ports
+}
+
+func portFromHost(host string, defaultPort int32) int32 {
+	_, portStr, err := net.SplitHostPort(host)
+	if err != nil {
+		return defaultPort
+	}
+	p, err := strconv.ParseInt(portStr, 10, 32)
+	if err != nil || p < 1 || p > 65535 {
+		return defaultPort
+	}
+	return int32(p)
+}
+
+func portFromProxyURL(rawURL string) int32 {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 443
+	}
+	if p := u.Port(); p != "" {
+		n, err := strconv.ParseInt(p, 10, 32)
+		if err != nil || n < 1 || n > 65535 {
+			return 443
+		}
+		return int32(n)
+	}
+	if u.Scheme == "http" {
+		return 80
+	}
+	return 443
+}
+
+func isClusterInternal(host string) bool {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+	return strings.HasSuffix(h, ".svc") || strings.Contains(h, ".svc.")
+}
+
 func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkingv1.NetworkPolicy {
+	ports := egressPorts(instance.Spec.Releases)
+	egressPolicyPorts := make([]networkingv1.NetworkPolicyPort, len(ports))
+	for i, p := range ports {
+		egressPolicyPorts[i] = networkingv1.NetworkPolicyPort{
+			Protocol: corev1ProtocolPtr(corev1.ProtocolTCP),
+			Port:     intOrStringPtr(intstr.FromInt32(p)),
+		}
+	}
+
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
 			Annotations: map[string]string{
-				DescriptionAnnotation: "This NetworkPolicy allows all egress, to support graph-builder scraping and DNS. " +
+				DescriptionAnnotation: "This NetworkPolicy restricts egress to the registry and proxy ports needed by graph-builder. " +
 					"It allows ingress from the router, to support serving policy-engine responses. " +
 					"All other ingress is blocked, including, for now, metrics scraping.",
 			},
@@ -324,7 +399,6 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 				},
 			},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
-				// Traffic from the router to the policy-engine service
 				From: []networkingv1.NetworkPolicyPeer{{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -338,12 +412,8 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 				}},
 			}},
 			Egress: []networkingv1.NetworkPolicyEgressRule{{
-				// TCP access to all ports, for registry access, possibly via proxies
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: corev1ProtocolPtr(corev1.ProtocolTCP),
-				}},
+				Ports: egressPolicyPorts,
 			}, {
-				// DNS access to the cluster's openshift-dns DaemonSet.
 				To: []networkingv1.NetworkPolicyPeer{{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -366,7 +366,7 @@ func isClusterInternal(host string) bool {
 	if err != nil {
 		h = host
 	}
-	return strings.HasSuffix(h, ".svc") || strings.Contains(h, ".svc.")
+	return strings.HasSuffix(h, ".svc") || strings.HasSuffix(h, ".svc.cluster.local")
 }
 
 func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkingv1.NetworkPolicy {

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -317,15 +317,23 @@ func egressPorts(releases string) []int32 {
 	}
 
 	registry := strings.SplitN(releases, "/", 2)[0]
-	registryPort := portFromHost(registry, 443)
-	add(registryPort)
 
 	if !isClusterInternal(registry) {
 		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY"} {
 			if v := os.Getenv(env); v != "" {
-				add(portFromProxyURL(v))
+				if p, err := portFromProxyURL(v); err == nil {
+					add(p)
+				} else {
+					log.Error(err, "Failed to parse port from the proxy environment variable", "env", env, "value", v)
+				}
 			}
 		}
+	}
+
+	// When a proxy is configured for an external registry, the pod talks to
+	// the proxy, not the registry directly, so only proxy ports are needed.
+	if len(ports) == 0 {
+		add(portFromHost(registry, 443))
 	}
 
 	return ports
@@ -343,22 +351,26 @@ func portFromHost(host string, defaultPort int32) int32 {
 	return int32(p)
 }
 
-func portFromProxyURL(rawURL string) int32 {
+func portFromProxyURL(rawURL string) (int32, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return 443
+		return 0, fmt.Errorf("failed to parse proxy URL: %w", err)
 	}
 	if p := u.Port(); p != "" {
 		n, err := strconv.ParseInt(p, 10, 32)
 		if err != nil || n < 1 || n > 65535 {
-			return 443
+			return 0, fmt.Errorf("invalid port %q in proxy URL", p)
 		}
-		return int32(n)
+		return int32(n), nil
 	}
-	if u.Scheme == "http" {
-		return 80
+	switch u.Scheme {
+	case "http":
+		return 80, nil
+	case "https":
+		return 443, nil
+	default:
+		return 0, fmt.Errorf("invalid proxy URL scheme %q", u.Scheme)
 	}
-	return 443
 }
 
 func isClusterInternal(host string) bool {
@@ -384,7 +396,7 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
 			Annotations: map[string]string{
-				DescriptionAnnotation: "This NetworkPolicy restricts egress to the registry and proxy ports needed by graph-builder. " +
+				DescriptionAnnotation: "This NetworkPolicy allows egress restricted to the necessary ports, to support graph-builder scraping and DNS. " +
 					"It allows ingress from the router, to support serving policy-engine responses. " +
 					"All other ingress is blocked, including, for now, metrics scraping.",
 			},
@@ -399,6 +411,7 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 				},
 			},
 			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				// Traffic from the router to the policy-engine service
 				From: []networkingv1.NetworkPolicyPeer{{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -412,6 +425,7 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 				}},
 			}},
 			Egress: []networkingv1.NetworkPolicyEgressRule{{
+				// TCP access to the necessary ports, for registry access, possibly via proxies
 				Ports: egressPolicyPorts,
 			}, {
 				To: []networkingv1.NetworkPolicyPeer{{

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -77,3 +77,140 @@ func Test_newKubeResources(t *testing.T) {
 	}
 	assert.Empty(t, existing.Difference(collected), "We should extend the mapping in the test to allow for more fixture files")
 }
+
+func Test_egressPorts(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		releases   string
+		httpProxy  string
+		httpsProxy string
+		expected   []int32
+	}{
+		{
+			name:     "default port when no port in registry URI",
+			releases: "quay.io/openshift-release-dev/ocp-release",
+			expected: []int32{443},
+		},
+		{
+			name:     "explicit port in registry URI",
+			releases: "registry.example.com:8080/openshift/release",
+			expected: []int32{8080},
+		},
+		{
+			name:       "proxy port included for external registry",
+			releases:   "quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "http://proxy.example.com:3128",
+			expected:   []int32{443, 3128},
+		},
+		{
+			name:       "proxy port ignored for cluster-internal registry (.svc)",
+			releases:   "image-registry.openshift-image-registry.svc:5000/openshift/release",
+			httpsProxy: "http://proxy.example.com:3128",
+			expected:   []int32{5000},
+		},
+		{
+			name:       "proxy port ignored for .svc.cluster.local registry",
+			releases:   "quay.apps.internal.svc.cluster.local:5000/openshift/release",
+			httpsProxy: "http://proxy.example.com:3128",
+			expected:   []int32{5000},
+		},
+		{
+			name:      "HTTP_PROXY port used when set",
+			releases:  "quay.io/openshift-release-dev/ocp-release",
+			httpProxy: "http://proxy.example.com:8888",
+			expected:  []int32{443, 8888},
+		},
+		{
+			name:       "dedup when proxy port equals registry port",
+			releases:   "quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "http://proxy.example.com:443",
+			expected:   []int32{443},
+		},
+		{
+			name:       "proxy without explicit port defaults to 443 for https",
+			releases:   "quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "https://proxy.example.com",
+			expected:   []int32{443},
+		},
+		{
+			name:      "proxy without explicit port defaults to 80 for http",
+			releases:  "quay.io/openshift-release-dev/ocp-release",
+			httpProxy: "http://proxy.example.com",
+			expected:  []int32{80, 443},
+		},
+		{
+			name:       "both HTTP_PROXY and HTTPS_PROXY with different ports",
+			releases:   "quay.io/openshift-release-dev/ocp-release",
+			httpProxy:  "http://proxy.example.com:8080",
+			httpsProxy: "http://proxy.example.com:3128",
+			expected:   []int32{443, 8080, 3128},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HTTP_PROXY", tc.httpProxy)
+			t.Setenv("HTTPS_PROXY", tc.httpsProxy)
+
+			got := egressPorts(tc.releases)
+			assert.ElementsMatch(t, tc.expected, got)
+		})
+	}
+}
+
+func Test_newNetworkPolicy_egress_ports(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		releases   string
+		httpProxy  string
+		httpsProxy string
+		wantPorts  []int32
+	}{
+		{
+			name:      "default registry gets port 443",
+			releases:  "quay.io/openshift-release-dev/ocp-release",
+			wantPorts: []int32{443},
+		},
+		{
+			name:      "custom port in registry URI",
+			releases:  "registry.example.com:5000/library/images",
+			wantPorts: []int32{5000},
+		},
+		{
+			name:       "proxy port added for external registry",
+			releases:   "quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "http://squid.corp:3128",
+			wantPorts:  []int32{443, 3128},
+		},
+		{
+			name:       "proxy port ignored for .svc registry",
+			releases:   "image-registry.openshift-image-registry.svc:5000/openshift/release",
+			httpsProxy: "http://squid.corp:3128",
+			wantPorts:  []int32{5000},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HTTP_PROXY", tc.httpProxy)
+			t.Setenv("HTTPS_PROXY", tc.httpsProxy)
+
+			instance := &cv1.UpdateService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-ns",
+				},
+				Spec: cv1.UpdateServiceSpec{
+					Releases: tc.releases,
+				},
+			}
+			k := &kubeResources{}
+			np := k.newNetworkPolicy(instance)
+
+			// First egress rule should have specific ports
+			assert.NotEmpty(t, np.Spec.Egress)
+			registryEgress := np.Spec.Egress[0]
+			var gotPorts []int32
+			for _, p := range registryEgress.Ports {
+				gotPorts = append(gotPorts, p.Port.IntVal)
+			}
+			assert.ElementsMatch(t, tc.wantPorts, gotPorts)
+		})
+	}
+}

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -139,6 +139,12 @@ func Test_egressPorts(t *testing.T) {
 			expected:  []int32{80, 443},
 		},
 		{
+			name:       "host with svc in domain name is not cluster-internal",
+			releases:   "my.svc.company.com/openshift/release",
+			httpsProxy: "http://proxy.example.com:3128",
+			expected:   []int32{443, 3128},
+		},
+		{
 			name:       "both HTTP_PROXY and HTTPS_PROXY with different ports",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
 			httpProxy:  "http://proxy.example.com:8080",

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -97,10 +97,10 @@ func Test_egressPorts(t *testing.T) {
 			expected: []int32{8080},
 		},
 		{
-			name:       "proxy port included for external registry",
+			name:       "proxy port used instead of registry port for external registry",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
 			httpsProxy: "http://proxy.example.com:3128",
-			expected:   []int32{443, 3128},
+			expected:   []int32{3128},
 		},
 		{
 			name:       "proxy port ignored for cluster-internal registry (.svc)",
@@ -115,10 +115,10 @@ func Test_egressPorts(t *testing.T) {
 			expected:   []int32{5000},
 		},
 		{
-			name:      "HTTP_PROXY port used when set",
+			name:      "HTTP_PROXY port used instead of registry port",
 			releases:  "quay.io/openshift-release-dev/ocp-release",
 			httpProxy: "http://proxy.example.com:8888",
-			expected:  []int32{443, 8888},
+			expected:  []int32{8888},
 		},
 		{
 			name:       "dedup when proxy port equals registry port",
@@ -136,20 +136,31 @@ func Test_egressPorts(t *testing.T) {
 			name:      "proxy without explicit port defaults to 80 for http",
 			releases:  "quay.io/openshift-release-dev/ocp-release",
 			httpProxy: "http://proxy.example.com",
-			expected:  []int32{80, 443},
+			expected:  []int32{80},
 		},
 		{
 			name:       "host with svc in domain name is not cluster-internal",
 			releases:   "my.svc.company.com/openshift/release",
 			httpsProxy: "http://proxy.example.com:3128",
-			expected:   []int32{443, 3128},
+			expected:   []int32{3128},
 		},
 		{
 			name:       "both HTTP_PROXY and HTTPS_PROXY with different ports",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
-			httpProxy:  "http://proxy.example.com:8080",
-			httpsProxy: "http://proxy.example.com:3128",
-			expected:   []int32{443, 8080, 3128},
+			httpProxy:  "http://user:pass@proxy.example.com:8080",
+			httpsProxy: "http://user:pass@proxy.example.com:3128",
+			expected:   []int32{8080, 3128},
+		}, {
+			name:       "bad proxy",
+			releases:   "my.svc.company.com/openshift/release",
+			httpsProxy: "i am a very bad proxy",
+			expected:   []int32{443},
+		},
+		{
+			name:      "bad proxy port",
+			releases:  "my.svc.company.com/openshift/release",
+			httpProxy: "http://user:pass@proxy.example.com:80000080",
+			expected:  []int32{443},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -181,10 +192,10 @@ func Test_newNetworkPolicy_egress_ports(t *testing.T) {
 			wantPorts: []int32{5000},
 		},
 		{
-			name:       "proxy port added for external registry",
+			name:       "proxy port replaces registry port for external registry",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
 			httpsProxy: "http://squid.corp:3128",
-			wantPorts:  []int32{443, 3128},
+			wantPorts:  []int32{3128},
 		},
 		{
 			name:       "proxy port ignored for .svc registry",
@@ -215,6 +226,7 @@ func Test_newNetworkPolicy_egress_ports(t *testing.T) {
 			var gotPorts []int32
 			for _, p := range registryEgress.Ports {
 				gotPorts = append(gotPorts, p.Port.IntVal)
+				assert.Equal(t, corev1.ProtocolTCP, *p.Protocol)
 			}
 			assert.ElementsMatch(t, tc.wantPorts, gotPorts)
 		})

--- a/controllers/testdata/resources/zz_fixture_Test_newKubeResources_network_policy.yaml
+++ b/controllers/testdata/resources/zz_fixture_Test_newKubeResources_network_policy.yaml
@@ -1,8 +1,9 @@
 metadata:
   annotations:
-    kubernetes.io/description: This NetworkPolicy allows all egress, to support graph-builder
-      scraping and DNS. It allows ingress from the router, to support serving policy-engine
-      responses. All other ingress is blocked, including, for now, metrics scraping.
+    kubernetes.io/description: This NetworkPolicy restricts egress to the registry
+      and proxy ports needed by graph-builder. It allows ingress from the router,
+      to support serving policy-engine responses. All other ingress is blocked, including,
+      for now, metrics scraping.
   creationTimestamp: null
   labels:
     app: sample
@@ -11,7 +12,8 @@ metadata:
 spec:
   egress:
   - ports:
-    - protocol: TCP
+    - port: 443
+      protocol: TCP
   - ports:
     - port: 5353
       protocol: TCP

--- a/controllers/testdata/resources/zz_fixture_Test_newKubeResources_network_policy.yaml
+++ b/controllers/testdata/resources/zz_fixture_Test_newKubeResources_network_policy.yaml
@@ -1,9 +1,9 @@
 metadata:
   annotations:
-    kubernetes.io/description: This NetworkPolicy restricts egress to the registry
-      and proxy ports needed by graph-builder. It allows ingress from the router,
-      to support serving policy-engine responses. All other ingress is blocked, including,
-      for now, metrics scraping.
+    kubernetes.io/description: This NetworkPolicy allows egress restricted to the
+      necessary ports, to support graph-builder scraping and DNS. It allows ingress
+      from the router, to support serving policy-engine responses. All other ingress
+      is blocked, including, for now, metrics scraping.
   creationTimestamp: null
   labels:
     app: sample

--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -660,7 +660,7 @@ func TestEnsureNetworkPolicy(t *testing.T) {
 	}
 
 	verifyOwnerReference(t, found.ObjectMeta.OwnerReferences[0], updateservice)
-	verifyAnnotation(t, found.ObjectMeta.Annotations, "NetworkPolicy", "egress", "registry")
+	verifyAnnotation(t, found.ObjectMeta.Annotations, "NetworkPolicy", "egress")
 	assert.Equal(t, found.ObjectMeta.Labels["app"], updateservice.Name)
 
 	assert.Equal(t, found.Spec.PodSelector.MatchLabels["app"], nameDeployment(updateservice))
@@ -671,7 +671,7 @@ func TestEnsureNetworkPolicy(t *testing.T) {
 	assert.Equal(t, 2, len(found.Spec.Egress), "should have 2 egress rules: registry and DNS")
 	assert.Equal(t, 1, len(found.Spec.Egress[0].Ports), "first egress rule should have 1 port for default registry")
 	assert.Equal(t, intstr.FromInt32(443), *found.Spec.Egress[0].Ports[0].Port, "registry port should be 443")
-	assert.Equal(t, intstr.FromInt32(5353), *found.Spec.Egress[1].Ports[0].Port, "DNS egress port should be 5353")
+	assert.Equal(t, intstr.FromInt32(5353), *found.Spec.Egress[1].Ports[0].Port, "DNS egress port for TCP should be 5353")
 }
 
 func TestEnsureNetworkPolicyUpdatesOnPortChange(t *testing.T) {

--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -635,6 +635,10 @@ func TestEnsurePolicyEngineRoute(t *testing.T) {
 }
 
 func TestEnsureNetworkPolicyUpdatesOnPortChange(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("NO_PROXY", "")
+
 	pullSecret := newSecret()
 	updateservice := &cv1.UpdateService{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -634,6 +634,46 @@ func TestEnsurePolicyEngineRoute(t *testing.T) {
 	}
 }
 
+func TestEnsureNetworkPolicy(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("NO_PROXY", "")
+
+	pullSecret := newSecret()
+	updateservice := newDefaultUpdateService()
+	r := newTestReconciler(updateservice)
+
+	resources, err := newKubeResources(updateservice, testOperandImage, pullSecret, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = r.ensureNetworkPolicy(context.TODO(), log, updateservice, resources)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := &networkingv1.NetworkPolicy{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: updateservice.Name, Namespace: updateservice.Namespace}, found)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifyOwnerReference(t, found.ObjectMeta.OwnerReferences[0], updateservice)
+	verifyAnnotation(t, found.ObjectMeta.Annotations, "NetworkPolicy", "egress", "registry")
+	assert.Equal(t, found.ObjectMeta.Labels["app"], updateservice.Name)
+
+	assert.Equal(t, found.Spec.PodSelector.MatchLabels["app"], nameDeployment(updateservice))
+
+	assert.NotEmpty(t, found.Spec.Ingress, "should have ingress rules")
+	assert.Equal(t, intstr.FromString("policy-engine"), *found.Spec.Ingress[0].Ports[0].Port)
+
+	assert.Equal(t, 2, len(found.Spec.Egress), "should have 2 egress rules: registry and DNS")
+	assert.Equal(t, 1, len(found.Spec.Egress[0].Ports), "first egress rule should have 1 port for default registry")
+	assert.Equal(t, intstr.FromInt32(443), *found.Spec.Egress[0].Ports[0].Port, "registry port should be 443")
+	assert.Equal(t, intstr.FromInt32(5353), *found.Spec.Egress[1].Ports[0].Port, "DNS egress port should be 5353")
+}
+
 func TestEnsureNetworkPolicyUpdatesOnPortChange(t *testing.T) {
 	t.Setenv("HTTP_PROXY", "")
 	t.Setenv("HTTPS_PROXY", "")

--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -16,6 +16,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -631,6 +632,57 @@ func TestEnsurePolicyEngineRoute(t *testing.T) {
 			assert.Equal(t, found.Spec.Port.TargetPort, intstr.FromString("policy-engine"))
 		})
 	}
+}
+
+func TestEnsureNetworkPolicyUpdatesOnPortChange(t *testing.T) {
+	pullSecret := newSecret()
+	updateservice := &cv1.UpdateService{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       testUpdateServiceKind,
+			APIVersion: testUpdateServiceAPIVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: cv1.UpdateServiceSpec{
+			Replicas:       testReplicas,
+			Releases:       "quay.io/ocp-release/release",
+			GraphDataImage: testGraphDataImage,
+		},
+	}
+
+	// Get expected NetworkPolicy (port 443 for quay.io)
+	resources, err := newKubeResources(updateservice, testOperandImage, pullSecret, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPolicy := resources.networkPolicy
+
+	// Create "stale" NetworkPolicy with port 8080 instead of 443
+	oldPolicy := expectedPolicy.DeepCopy()
+	oldPolicy.Spec.Egress[0].Ports[0].Port = intOrStringPtr(intstr.FromInt32(8080))
+
+	// Set up reconciler with the old policy already existing
+	r := newTestReconciler(updateservice, oldPolicy)
+
+	// Call ensureNetworkPolicy
+	err = r.ensureNetworkPolicy(context.TODO(), log, updateservice, resources)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch the NetworkPolicy and verify the port was updated to 443
+	found := &networkingv1.NetworkPolicy{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: updateservice.Name, Namespace: updateservice.Namespace}, found)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the port was updated to 443 in the first egress rule (registry egress)
+	assert.Equal(t, 2, len(found.Spec.Egress), "should have 2 egress rules: registry and DNS")
+	assert.Equal(t, 1, len(found.Spec.Egress[0].Ports), "first egress rule should have 1 port")
+	assert.Equal(t, intstr.FromInt32(443), *found.Spec.Egress[0].Ports[0].Port, "registry port should be 443 for quay.io")
 }
 
 func newRequest(updateservice *cv1.UpdateService) reconcile.Request {


### PR DESCRIPTION
The NetworkPolicy now only allows egress on the specific TCP ports needed: the registry port (from spec.releases, default 443) and proxy ports (from HTTP_PROXY/HTTPS_PROXY env vars). Proxy ports are excluded when the registry is cluster-internal (.svc).

following up on PR: #243 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NetworkPolicies now restrict UpdateService pod egress to a de-duplicated set of registry and proxy TCP ports; registry defaults to 443 when unspecified and proxy defaults (HTTPS→443, HTTP→80) are applied. Cluster-internal registries (.svc/*.svc.cluster.local) are excluded from proxy routing.

* **Bug Fixes**
  * Ensure existing NetworkPolicies are updated when egress ports change.

* **Tests**
  * Added tests for port selection, proxy handling, deduplication, cluster-internal detection, and policy generation/update.

* **Documentation**
  * Updated NetworkPolicy description to reflect restricted egress to necessary registry/proxy ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->