### PR TITLE
OTA-1639: Restrict osus egress namespace

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -328,7 +328,7 @@ func egressPorts(releases string) []int32 {
 
 	registryNoProxy := noProxy(registry)
 
-	if !isClusterInternal(registry) && !registryNoProxy {
+	if namespaceFromInternalHost(registry) == "" && !registryNoProxy {
 		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY"} {
 			if v := os.Getenv(env); v != "" {
 				add(v, false)
@@ -400,12 +400,26 @@ func portFromURL(rawURL string) (int32, string, error) {
 	}
 }
 
-func isClusterInternal(host string) bool {
+func namespaceFromInternalHost(host string) string {
 	h, _, err := net.SplitHostPort(host)
 	if err != nil {
 		h = host
 	}
-	return strings.HasSuffix(h, ".svc") || strings.HasSuffix(h, ".svc.cluster.local")
+	const svcSuffix = ".svc"
+	const svcClusterLocalSuffix = ".svc.cluster.local"
+	var prefix string
+	var found bool
+	if prefix, found = strings.CutSuffix(h, svcClusterLocalSuffix); !found {
+		prefix, found = strings.CutSuffix(h, svcSuffix)
+	}
+	if !found {
+		return ""
+	}
+	parts := strings.Split(prefix, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-1]
 }
 
 func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkingv1.NetworkPolicy {
@@ -418,12 +432,28 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 		}
 	}
 
+	registry := strings.SplitN(instance.Spec.Releases, "/", 2)[0]
+	registryEgress := networkingv1.NetworkPolicyEgressRule{
+		Ports: egressPolicyPorts,
+	}
+	egressDescription := "This NetworkPolicy allows egress restricted to the necessary ports, to support graph-builder scraping and DNS. "
+	if ns := namespaceFromInternalHost(registry); ns != "" {
+		registryEgress.To = []networkingv1.NetworkPolicyPeer{{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					corev1.LabelMetadataName: ns,
+				},
+			},
+		}}
+		egressDescription = fmt.Sprintf("This NetworkPolicy allows egress restricted to namespace %s on the necessary ports, to support graph-builder scraping and DNS. ", ns)
+	}
+
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
 			Annotations: map[string]string{
-				DescriptionAnnotation: "This NetworkPolicy allows egress restricted to the necessary ports, to support graph-builder scraping and DNS. " +
+				DescriptionAnnotation: egressDescription +
 					"It allows ingress from the router, to support serving policy-engine responses. " +
 					"All other ingress is blocked, including, for now, metrics scraping.",
 			},
@@ -451,30 +481,29 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 					Port:     intOrStringPtr(intstr.FromString("policy-engine")),
 				}},
 			}},
-			Egress: []networkingv1.NetworkPolicyEgressRule{{
-				// TCP access to the necessary ports, for registry access, possibly via proxies
-				Ports: egressPolicyPorts,
-			}, {
-				To: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"kubernetes.io/metadata.name": "openshift-dns",
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				// TCP access only to the necessary ports, for registry access, possibly via proxies
+				registryEgress, {
+					To: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/metadata.name": "openshift-dns",
+							},
 						},
-					},
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"dns.operator.openshift.io/daemonset-dns": "default",
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"dns.operator.openshift.io/daemonset-dns": "default",
+							},
 						},
-					},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{{
+						Protocol: corev1ProtocolPtr(corev1.ProtocolTCP),
+						Port:     intOrStringPtr(intstr.FromInt32(5353)),
+					}, {
+						Protocol: corev1ProtocolPtr(corev1.ProtocolUDP),
+						Port:     intOrStringPtr(intstr.FromInt32(5353)),
+					}},
 				}},
-				Ports: []networkingv1.NetworkPolicyPort{{
-					Protocol: corev1ProtocolPtr(corev1.ProtocolTCP),
-					Port:     intOrStringPtr(intstr.FromInt32(5353)),
-				}, {
-					Protocol: corev1ProtocolPtr(corev1.ProtocolUDP),
-					Port:     intOrStringPtr(intstr.FromInt32(5353)),
-				}},
-			}},
 		},
 	}
 }

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -223,6 +223,56 @@ func Test_egressPorts(t *testing.T) {
 	}
 }
 
+func Test_namespaceFromInternalHost(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		host     string
+		expected string
+	}{
+		{
+			name:     "service.namespace.svc",
+			host:     "image-registry.openshift-image-registry.svc",
+			expected: "openshift-image-registry",
+		},
+		{
+			name:     "service.namespace.svc.cluster.local",
+			host:     "image-registry.openshift-image-registry.svc.cluster.local",
+			expected: "openshift-image-registry",
+		},
+		{
+			name:     "service.namespace.svc with port",
+			host:     "image-registry.openshift-image-registry.svc:5000",
+			expected: "openshift-image-registry",
+		},
+		{
+			name:     "service.namespace.svc.cluster.local with port",
+			host:     "image-registry.openshift-image-registry.svc.cluster.local:5000",
+			expected: "openshift-image-registry",
+		},
+		{
+			name: "external host returns empty",
+			host: "quay.io",
+		},
+		{
+			name: "bare hostname returns empty",
+			host: "localhost",
+		},
+		{
+			name: "svc in domain name but not cluster-internal",
+			host: "my.svc.company.com",
+		},
+		{
+			name: "service only with .svc suffix returns empty",
+			host: "registry.svc",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := namespaceFromInternalHost(tc.host)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}
+
 func Test_newNetworkPolicy_egress_ports(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -279,6 +329,55 @@ func Test_newNetworkPolicy_egress_ports(t *testing.T) {
 				assert.Equal(t, corev1.ProtocolTCP, *p.Protocol)
 			}
 			assert.ElementsMatch(t, tc.wantPorts, gotPorts)
+		})
+	}
+}
+
+func Test_newNetworkPolicy_egress_namespace(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		releases      string
+		wantNamespace string
+	}{
+		{
+			name:          "external registry has no namespace restriction",
+			releases:      "quay.io/openshift-release-dev/ocp-release",
+			wantNamespace: "",
+		},
+		{
+			name:          "cluster-internal .svc restricts to namespace",
+			releases:      "image-registry.openshift-image-registry.svc:5000/openshift/release",
+			wantNamespace: "openshift-image-registry",
+		},
+		{
+			name:          "cluster-internal .svc.cluster.local restricts to namespace",
+			releases:      "image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/release",
+			wantNamespace: "openshift-image-registry",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HTTP_PROXY", "")
+			t.Setenv("HTTPS_PROXY", "")
+
+			instance := &cv1.UpdateService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-ns",
+				},
+				Spec: cv1.UpdateServiceSpec{
+					Releases: tc.releases,
+				},
+			}
+			k := &kubeResources{}
+			np := k.newNetworkPolicy(instance)
+
+			registryEgress := np.Spec.Egress[0]
+			if tc.wantNamespace == "" {
+				assert.Empty(t, registryEgress.To, "external registry should have no destination restriction")
+			} else {
+				assert.Len(t, registryEgress.To, 1)
+				assert.Equal(t, tc.wantNamespace, registryEgress.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+			}
 		})
 	}
 }


### PR DESCRIPTION
When spec.releases points to a cluster-internal registry (.svc), the NetworkPolicy now restricts egress to only that registry's namespace using a namespaceSelector, blocking all cluster-external traffic.

~~blocked by #264 being merged first~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better detection of cluster-internal registries with stricter hostname validation.
  * Network policies now add a dedicated registry egress rule and apply namespace-specific egress restrictions for internal registries while leaving external registries unrestricted.
  * Network policies include clearer descriptive annotations about egress behavior.

* **Tests**
  * Added tests validating namespace extraction from internal service hostnames and egress namespace behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->