### PR TITLE
NO-JIRA: Use portFromURL to replace portFromHost

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -309,7 +309,15 @@ func (k *kubeResources) oldPolicyEngineRoute(instance *cv1.UpdateService) *route
 func egressPorts(releases string) []int32 {
 	seen := map[int32]bool{}
 	var ports []int32
-	add := func(p int32) {
+	add := func(url string, addDefaultOnErr bool) {
+		p, err := portFromURL(url)
+		if err != nil {
+			log.Error(err, "Failed to parse port from url", "url", url)
+			if !addDefaultOnErr {
+				return
+			}
+			p = 443
+		}
 		if !seen[p] {
 			seen[p] = true
 			ports = append(ports, p)
@@ -321,11 +329,7 @@ func egressPorts(releases string) []int32 {
 	if !isClusterInternal(registry) {
 		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY"} {
 			if v := os.Getenv(env); v != "" {
-				if p, err := portFromURL(v); err == nil {
-					add(p)
-				} else {
-					log.Error(err, "Failed to parse port from the proxy environment variable", "env", env, "value", v)
-				}
+				add(v, false)
 			}
 		}
 	}
@@ -333,14 +337,7 @@ func egressPorts(releases string) []int32 {
 	// When a proxy is configured for an external registry, the pod talks to
 	// the proxy, not the registry directly, so only proxy ports are needed.
 	if len(ports) == 0 {
-		registryURL := "https://" + registry
-		p, err := portFromURL(registryURL)
-		if err == nil {
-			add(p)
-		} else {
-			add(443)
-			log.Error(err, "Failed to parse port from the registry url and use the default port 433", "registryURL", registryURL)
-		}
+		add("https://"+registry, true)
 	}
 	return ports
 }

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -378,7 +378,7 @@ func noProxy(registry string) bool {
 func portFromURL(rawURL string) (int32, string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return 0, "url is redacted", fmt.Errorf("failed to parse proxy URL: %w", err)
+		return 0, "url is redacted", fmt.Errorf("failed to parse URL: %w", err)
 	}
 	if u.User != nil {
 		u.User = url.UserPassword("xxx", "xxx")
@@ -386,7 +386,7 @@ func portFromURL(rawURL string) (int32, string, error) {
 	if p := u.Port(); p != "" {
 		n, err := strconv.ParseInt(p, 10, 32)
 		if err != nil || n < 1 || n > 65535 {
-			return 0, u.String(), fmt.Errorf("invalid port %q in proxy URL", p)
+			return 0, u.String(), fmt.Errorf("invalid port %q in URL", p)
 		}
 		return int32(n), u.String(), nil
 	}
@@ -396,7 +396,7 @@ func portFromURL(rawURL string) (int32, string, error) {
 	case "https":
 		return 443, u.String(), nil
 	default:
-		return 0, u.String(), fmt.Errorf("invalid proxy URL scheme %q", u.Scheme)
+		return 0, u.String(), fmt.Errorf("invalid URL scheme %q", u.Scheme)
 	}
 }
 

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -321,7 +321,7 @@ func egressPorts(releases string) []int32 {
 	if !isClusterInternal(registry) {
 		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY"} {
 			if v := os.Getenv(env); v != "" {
-				if p, err := portFromProxyURL(v); err == nil {
+				if p, err := portFromURL(v); err == nil {
 					add(p)
 				} else {
 					log.Error(err, "Failed to parse port from the proxy environment variable", "env", env, "value", v)
@@ -333,25 +333,19 @@ func egressPorts(releases string) []int32 {
 	// When a proxy is configured for an external registry, the pod talks to
 	// the proxy, not the registry directly, so only proxy ports are needed.
 	if len(ports) == 0 {
-		add(portFromHost(registry, 443))
+		registryURL := "https://" + registry
+		p, err := portFromURL(registryURL)
+		if err == nil {
+			add(p)
+		} else {
+			add(443)
+			log.Error(err, "Failed to parse port from the registry url and use the default port 433", "registryURL", registryURL)
+		}
 	}
-
 	return ports
 }
 
-func portFromHost(host string, defaultPort int32) int32 {
-	_, portStr, err := net.SplitHostPort(host)
-	if err != nil {
-		return defaultPort
-	}
-	p, err := strconv.ParseInt(portStr, 10, 32)
-	if err != nil || p < 1 || p > 65535 {
-		return defaultPort
-	}
-	return int32(p)
-}
-
-func portFromProxyURL(rawURL string) (int32, error) {
+func portFromURL(rawURL string) (int32, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse proxy URL: %w", err)

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -310,9 +310,9 @@ func egressPorts(releases string) []int32 {
 	seen := map[int32]bool{}
 	var ports []int32
 	add := func(url string, addDefaultOnErr bool) {
-		p, err := portFromURL(url)
+		p, redacted, err := portFromURL(url)
 		if err != nil {
-			log.Error(err, "Failed to parse port from url", "url", url)
+			log.Error(err, "Failed to parse port from url", "url", redacted)
 			if !addDefaultOnErr {
 				return
 			}
@@ -342,25 +342,28 @@ func egressPorts(releases string) []int32 {
 	return ports
 }
 
-func portFromURL(rawURL string) (int32, error) {
+func portFromURL(rawURL string) (int32, string, error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse proxy URL: %w", err)
+		return 0, "url is redacted", fmt.Errorf("failed to parse proxy URL: %w", err)
+	}
+	if u.User != nil {
+		u.User = url.UserPassword("xxx", "xxx")
 	}
 	if p := u.Port(); p != "" {
 		n, err := strconv.ParseInt(p, 10, 32)
 		if err != nil || n < 1 || n > 65535 {
-			return 0, fmt.Errorf("invalid port %q in proxy URL", p)
+			return 0, u.String(), fmt.Errorf("invalid port %q in proxy URL", p)
 		}
-		return int32(n), nil
+		return int32(n), u.String(), nil
 	}
 	switch u.Scheme {
 	case "http":
-		return 80, nil
+		return 80, u.String(), nil
 	case "https":
-		return 443, nil
+		return 443, u.String(), nil
 	default:
-		return 0, fmt.Errorf("invalid proxy URL scheme %q", u.Scheme)
+		return 0, u.String(), fmt.Errorf("invalid proxy URL scheme %q", u.Scheme)
 	}
 }
 

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -326,7 +326,9 @@ func egressPorts(releases string) []int32 {
 
 	registry := strings.SplitN(releases, "/", 2)[0]
 
-	if !isClusterInternal(registry) {
+	registryNoProxy := noProxy(registry)
+
+	if !isClusterInternal(registry) && !registryNoProxy {
 		for _, env := range []string{"HTTP_PROXY", "HTTPS_PROXY"} {
 			if v := os.Getenv(env); v != "" {
 				add(v, false)
@@ -340,6 +342,37 @@ func egressPorts(releases string) []int32 {
 		add("https://"+registry, true)
 	}
 	return ports
+}
+
+func noProxy(registry string) bool {
+	noProxyEnv := os.Getenv("NO_PROXY")
+	if noProxyEnv == "" {
+		return false
+	}
+	// ref. https://docs.redhat.com/en/documentation/openshift_container_platform/3.11/html/configuring_clusters/install-config-http-proxies
+	// Example from the doc: NO_PROXY=master.hostname.example.com,10.1.0.0/16,172.30.0.0/16
+	if i := strings.IndexAny(registry, ":"); i > -1 {
+		registry = registry[:i]
+	}
+	for _, s := range strings.Split(noProxyEnv, ",") {
+		trimmed := strings.TrimSpace(s)
+		if trimmed == "*" {
+			return true
+		}
+		if trimmed == registry {
+			return true
+		}
+		// Subdomain Wildcards
+		if strings.HasPrefix(trimmed, ".") && strings.HasSuffix(registry, trimmed) {
+			return true
+		}
+		if ip := net.ParseIP(registry); ip != nil {
+			if _, ipNet, err := net.ParseCIDR(trimmed); err == nil && ipNet.Contains(ip) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func portFromURL(rawURL string) (int32, string, error) {

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -127,6 +127,12 @@ func Test_egressPorts(t *testing.T) {
 			expected:   []int32{443},
 		},
 		{
+			name:       "http proxy with IP",
+			releases:   "quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "https://127.0.0.1:8443",
+			expected:   []int32{8443},
+		},
+		{
 			name:       "proxy without explicit port defaults to 443 for https",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
 			httpsProxy: "https://proxy.example.com",

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -84,6 +84,7 @@ func Test_egressPorts(t *testing.T) {
 		releases   string
 		httpProxy  string
 		httpsProxy string
+		noProxy    string
 		expected   []int32
 	}{
 		{
@@ -101,6 +102,48 @@ func Test_egressPorts(t *testing.T) {
 			releases:   "quay.io/openshift-release-dev/ocp-release",
 			httpsProxy: "http://proxy.example.com:3128",
 			expected:   []int32{3128},
+		},
+		{
+			name:       "registry as no proxy",
+			releases:   "quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "https://proxy.example.com:3128",
+			noProxy:    "quay.io, docker.io",
+			expected:   []int32{443},
+		},
+		{
+			name:       "registry and no proxy with ip",
+			releases:   "10.1.0.3:8443/openshift-release-dev/ocp-release",
+			httpsProxy: "https://proxy.example.com:3128",
+			noProxy:    "10.1.0.3, quay.io, docker.io",
+			expected:   []int32{8443},
+		},
+		{
+			name:       "registry and no proxy with CIDR",
+			releases:   "10.1.0.2:8443/openshift-release-dev/ocp-release",
+			httpsProxy: "https://proxy.example.com:3128",
+			noProxy:    "10.1.0.0/16, quay.io, docker.io",
+			expected:   []int32{8443},
+		},
+		{
+			name:       "registry and no proxy with exact subdomain",
+			releases:   "sub.quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "https://proxy.example.com:3128",
+			noProxy:    "quay.io, docker.io",
+			expected:   []int32{3128},
+		},
+		{
+			name:       "registry and no proxy with dot",
+			releases:   "sub.quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "https://proxy.example.com:3128",
+			noProxy:    ".quay.io, docker.io",
+			expected:   []int32{443},
+		},
+		{
+			name:       "registry and no proxy with asterisk",
+			releases:   "sub.quay.io/openshift-release-dev/ocp-release",
+			httpsProxy: "https://proxy.example.com:3128",
+			noProxy:    "docker.io, *",
+			expected:   []int32{443},
 		},
 		{
 			name:       "proxy port ignored for cluster-internal registry (.svc)",
@@ -172,6 +215,7 @@ func Test_egressPorts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("HTTP_PROXY", tc.httpProxy)
 			t.Setenv("HTTPS_PROXY", tc.httpsProxy)
+			t.Setenv("NO_PROXY", tc.noProxy)
 
 			got := egressPorts(tc.releases)
 			assert.ElementsMatch(t, tc.expected, got)

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -100,7 +100,7 @@ func Test_egressPorts(t *testing.T) {
 		{
 			name:       "proxy port used instead of registry port for external registry",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
-			httpsProxy: "http://proxy.example.com:3128",
+			httpsProxy: "https://proxy.example.com:3128",
 			expected:   []int32{3128},
 		},
 		{
@@ -148,25 +148,25 @@ func Test_egressPorts(t *testing.T) {
 		{
 			name:       "proxy port ignored for cluster-internal registry (.svc)",
 			releases:   "image-registry.openshift-image-registry.svc:5000/openshift/release",
-			httpsProxy: "http://proxy.example.com:3128",
+			httpsProxy: "https://proxy.example.com:3128",
 			expected:   []int32{5000},
 		},
 		{
 			name:       "proxy port ignored for .svc.cluster.local registry",
 			releases:   "quay.apps.internal.svc.cluster.local:5000/openshift/release",
-			httpsProxy: "http://proxy.example.com:3128",
+			httpsProxy: "https://proxy.example.com:3128",
 			expected:   []int32{5000},
 		},
 		{
 			name:      "HTTP_PROXY port used instead of registry port",
 			releases:  "quay.io/openshift-release-dev/ocp-release",
-			httpProxy: "http://proxy.example.com:8888",
+			httpProxy: "https://proxy.example.com:8888",
 			expected:  []int32{8888},
 		},
 		{
 			name:       "dedup when proxy port equals registry port",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
-			httpsProxy: "http://proxy.example.com:443",
+			httpsProxy: "https://proxy.example.com:443",
 			expected:   []int32{443},
 		},
 		{
@@ -190,14 +190,14 @@ func Test_egressPorts(t *testing.T) {
 		{
 			name:       "host with svc in domain name is not cluster-internal",
 			releases:   "my.svc.company.com/openshift/release",
-			httpsProxy: "http://proxy.example.com:3128",
+			httpsProxy: "https://proxy.example.com:3128",
 			expected:   []int32{3128},
 		},
 		{
 			name:       "both HTTP_PROXY and HTTPS_PROXY with different ports",
 			releases:   "quay.io/openshift-release-dev/ocp-release",
 			httpProxy:  "http://user:pass@proxy.example.com:8080",
-			httpsProxy: "http://user:pass@proxy.example.com:3128",
+			httpsProxy: "https://user:pass@proxy.example.com:3128",
 			expected:   []int32{8080, 3128},
 		}, {
 			name:       "bad proxy",


### PR DESCRIPTION
The pull simplifies the code a bit and does not change any existing functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate egress port detection by correctly parsing proxy environment variables and external registry addresses.
  * Improved error logging that redacts sensitive URL details.
  * Better handling of explicit proxy ports and sensible fallbacks when parsing fails.

* **Tests**
  * Expanded test coverage for proxy behavior, NO_PROXY bypass rules (including CIDR/IP forms), and proxy URLs using explicit IP:port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->