### PR TITLE
OTA-1747: add NetworkPolicy validation to e2e test

### DIFF
--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -639,39 +639,85 @@ func TestEnsureNetworkPolicy(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "")
 	t.Setenv("NO_PROXY", "")
 
-	pullSecret := newSecret()
-	updateservice := newDefaultUpdateService()
-	r := newTestReconciler(updateservice)
-
-	resources, err := newKubeResources(updateservice, testOperandImage, pullSecret, nil, nil)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name                 string
+		existingObjs         []runtime.Object
+		expectedEgress       int
+		expectedRegistryPort int32
+	}{
+		{
+			name: "CreateNetworkPolicy",
+			existingObjs: []runtime.Object{
+				newDefaultUpdateService(),
+				newSecret(),
+			},
+			expectedEgress:       2,
+			expectedRegistryPort: 443,
+		},
+		{
+			name: "CreateNetworkPolicyCustomPort",
+			existingObjs: []runtime.Object{
+				func() *cv1.UpdateService {
+					us := newDefaultUpdateService()
+					us.Spec.Releases = "myregistry.example.com:8443/ocp-release"
+					return us
+				}(),
+				newSecret(),
+			},
+			expectedEgress:       2,
+			expectedRegistryPort: 8443,
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := newTestReconciler(test.existingObjs...)
 
-	err = r.ensureNetworkPolicy(context.TODO(), log, updateservice, resources)
-	if err != nil {
-		t.Fatal(err)
+			updateservice := &cv1.UpdateService{}
+			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: testName, Namespace: testNamespace}, updateservice)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ps, err := r.findPullSecret(context.TODO(), log, updateservice)
+			if err != nil {
+				assert.Error(t, err)
+			}
+
+			resources, err := newKubeResources(updateservice, testOperandImage, ps, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = r.ensureNetworkPolicy(context.TODO(), log, updateservice, resources)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			found := &networkingv1.NetworkPolicy{}
+			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: updateservice.Name, Namespace: updateservice.Namespace}, found)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			verifyOwnerReference(t, found.ObjectMeta.OwnerReferences[0], updateservice)
+
+			// Ingress: router -> policy-engine
+			assert.Equal(t, 1, len(found.Spec.Ingress), "should have 1 ingress rule")
+			assert.Equal(t, intstr.FromString("policy-engine"), *found.Spec.Ingress[0].Ports[0].Port)
+			assert.Contains(t, found.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels, "policy-group.network.openshift.io/ingress")
+
+			// Egress: registry + DNS
+			assert.Equal(t, test.expectedEgress, len(found.Spec.Egress), "should have expected egress rules")
+			assert.Equal(t, intstr.FromInt32(test.expectedRegistryPort), *found.Spec.Egress[0].Ports[0].Port)
+			assert.Equal(t, corev1.ProtocolTCP, *found.Spec.Egress[0].Ports[0].Protocol)
+
+			// DNS egress
+			dnsEgress := found.Spec.Egress[1]
+			assert.Equal(t, "openshift-dns", dnsEgress.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+			assert.Equal(t, 2, len(dnsEgress.Ports), "DNS egress should have TCP+UDP ports")
+			assert.Equal(t, intstr.FromInt32(5353), *dnsEgress.Ports[0].Port)
+		})
 	}
-
-	found := &networkingv1.NetworkPolicy{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: updateservice.Name, Namespace: updateservice.Namespace}, found)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	verifyOwnerReference(t, found.ObjectMeta.OwnerReferences[0], updateservice)
-	verifyAnnotation(t, found.ObjectMeta.Annotations, "NetworkPolicy", "egress")
-	assert.Equal(t, found.ObjectMeta.Labels["app"], updateservice.Name)
-
-	assert.Equal(t, found.Spec.PodSelector.MatchLabels["app"], nameDeployment(updateservice))
-
-	assert.NotEmpty(t, found.Spec.Ingress, "should have ingress rules")
-	assert.Equal(t, intstr.FromString("policy-engine"), *found.Spec.Ingress[0].Ports[0].Port)
-
-	assert.Equal(t, 2, len(found.Spec.Egress), "should have 2 egress rules: registry and DNS")
-	assert.Equal(t, 1, len(found.Spec.Egress[0].Ports), "first egress rule should have 1 port for default registry")
-	assert.Equal(t, intstr.FromInt32(443), *found.Spec.Egress[0].Ports[0].Port, "registry port should be 443")
-	assert.Equal(t, intstr.FromInt32(5353), *found.Spec.Egress[1].Ports[0].Port, "DNS egress port for TCP should be 5353")
 }
 
 func TestEnsureNetworkPolicyUpdatesOnPortChange(t *testing.T) {

--- a/controllers/updateservice_controller_test.go
+++ b/controllers/updateservice_controller_test.go
@@ -716,6 +716,13 @@ func TestEnsureNetworkPolicy(t *testing.T) {
 			assert.Equal(t, "openshift-dns", dnsEgress.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
 			assert.Equal(t, 2, len(dnsEgress.Ports), "DNS egress should have TCP+UDP ports")
 			assert.Equal(t, intstr.FromInt32(5353), *dnsEgress.Ports[0].Port)
+			assert.Equal(t, intstr.FromInt32(5353), *dnsEgress.Ports[1].Port)
+			dnsProtocols := map[corev1.Protocol]bool{
+				*dnsEgress.Ports[0].Protocol: true,
+				*dnsEgress.Ports[1].Protocol: true,
+			}
+			assert.True(t, dnsProtocols[corev1.ProtocolTCP], "DNS egress should include TCP")
+			assert.True(t, dnsProtocols[corev1.ProtocolUDP], "DNS egress should include UDP")
 		})
 	}
 }

--- a/functests/updateservice_creation_test.go
+++ b/functests/updateservice_creation_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	updateservicev1 "github.com/openshift/cincinnati-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -122,6 +124,107 @@ func TestCustomResource(t *testing.T) {
 	}
 	t.Logf("PodDisruptionBudget %s available", operatorName)
 
+	// Checks to see if the NetworkPolicy is available and has the expected rules.
+	var networkPolicyFound bool
+	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		if _, err := k8sClient.NetworkingV1().NetworkPolicies(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				t.Logf("Waiting for availability of %s NetworkPolicy", customResourceName)
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	networkPolicyFound = true
+	t.Logf("NetworkPolicy %s available", customResourceName)
+
+	np, err := k8sClient.NetworkingV1().NetworkPolicies(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(np.OwnerReferences) < 1 {
+		t.Fatal("NetworkPolicy has no owner references")
+	}
+	if np.OwnerReferences[0].Name != customResourceName {
+		t.Fatalf("NetworkPolicy owner reference name %q does not match expected %q", np.OwnerReferences[0].Name, customResourceName)
+	}
+
+	// Validate ingress rules: router namespace → policy-engine port
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected 1 ingress rule, got %d", len(np.Spec.Ingress))
+	}
+	ingressRule := np.Spec.Ingress[0]
+	if len(ingressRule.From) != 1 {
+		t.Fatalf("expected 1 ingress peer, got %d", len(ingressRule.From))
+	}
+	ingressNSSelector := ingressRule.From[0].NamespaceSelector
+	if ingressNSSelector == nil {
+		t.Fatal("ingress rule missing namespace selector")
+	}
+	if _, ok := ingressNSSelector.MatchLabels["policy-group.network.openshift.io/ingress"]; !ok {
+		t.Fatal("ingress namespace selector missing policy-group.network.openshift.io/ingress label")
+	}
+	if len(ingressRule.Ports) != 1 {
+		t.Fatalf("expected 1 ingress port, got %d", len(ingressRule.Ports))
+	}
+	expectedIngressPort := intstr.FromString("policy-engine")
+	if *ingressRule.Ports[0].Port != expectedIngressPort {
+		t.Fatalf("expected ingress port %v, got %v", expectedIngressPort, *ingressRule.Ports[0].Port)
+	}
+
+	// Validate egress rules: registry (port 443 TCP) and DNS (openshift-dns, port 5353)
+	if len(np.Spec.Egress) != 2 {
+		t.Fatalf("expected 2 egress rules, got %d", len(np.Spec.Egress))
+	}
+
+	registryEgress := np.Spec.Egress[0]
+	if len(registryEgress.Ports) < 1 {
+		t.Fatal("registry egress rule has no ports")
+	}
+	expectedRegistryPort := intstr.FromInt32(443)
+	if *registryEgress.Ports[0].Port != expectedRegistryPort {
+		t.Fatalf("expected registry egress port %v, got %v", expectedRegistryPort, *registryEgress.Ports[0].Port)
+	}
+	if *registryEgress.Ports[0].Protocol != corev1.ProtocolTCP {
+		t.Fatalf("expected registry egress protocol TCP, got %v", *registryEgress.Ports[0].Protocol)
+	}
+	if len(registryEgress.To) != 0 {
+		t.Fatalf("expected no namespace restriction for external registry egress, got %d peers", len(registryEgress.To))
+	}
+
+	dnsEgress := np.Spec.Egress[1]
+	if len(dnsEgress.To) != 1 {
+		t.Fatalf("expected 1 DNS egress peer, got %d", len(dnsEgress.To))
+	}
+	dnsNSSelector := dnsEgress.To[0].NamespaceSelector
+	if dnsNSSelector == nil {
+		t.Fatal("DNS egress rule missing namespace selector")
+	}
+	if dnsNSSelector.MatchLabels["kubernetes.io/metadata.name"] != "openshift-dns" {
+		t.Fatalf("DNS egress namespace selector expected openshift-dns, got %q", dnsNSSelector.MatchLabels["kubernetes.io/metadata.name"])
+	}
+	dnsPodSelector := dnsEgress.To[0].PodSelector
+	if dnsPodSelector == nil {
+		t.Fatal("DNS egress rule missing pod selector")
+	}
+	if dnsPodSelector.MatchLabels["dns.operator.openshift.io/daemonset-dns"] != "default" {
+		t.Fatalf("DNS egress pod selector expected default, got %q", dnsPodSelector.MatchLabels["dns.operator.openshift.io/daemonset-dns"])
+	}
+	if len(dnsEgress.Ports) != 2 {
+		t.Fatalf("expected 2 DNS egress ports (TCP+UDP 5353), got %d", len(dnsEgress.Ports))
+	}
+	expectedDNSPort := intstr.FromInt32(5353)
+	for _, p := range dnsEgress.Ports {
+		if *p.Port != expectedDNSPort {
+			t.Fatalf("expected DNS port 5353, got %v", *p.Port)
+		}
+	}
+	t.Log("NetworkPolicy ingress and egress rules validated")
+
 	var policyEngineURI string
 	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		result := &updateservicev1.UpdateService{}
@@ -167,8 +270,27 @@ func TestCustomResource(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if networkPolicyFound {
+		t.Log("Route reachable with NetworkPolicy enforced — policy does not break real traffic")
+	}
 
 	if err := deleteCR(ctx); err != nil {
 		t.Log(err)
 	}
+
+	// Verify NetworkPolicy is garbage-collected after CR deletion via owner references.
+	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		_, err = k8sClient.NetworkingV1().NetworkPolicies(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		t.Logf("Waiting for deletion of %s NetworkPolicy", customResourceName)
+		return false, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("NetworkPolicy %s garbage-collected after CR deletion", customResourceName)
 }

--- a/functests/updateservice_creation_test.go
+++ b/functests/updateservice_creation_test.go
@@ -9,6 +9,7 @@ import (
 
 	updateservicev1 "github.com/openshift/cincinnati-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -110,7 +111,7 @@ func TestCustomResource(t *testing.T) {
 
 	// Checks to see if a given PodDisruptionBudget is available after a specified amount of time.
 	// If the PodDisruptionBudget is not available after 30 * retries seconds, the condition function returns an error.
-	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, retryInterval, timeout, true, func(_ context.Context) (done bool, err error) {
 		if _, err := k8sClient.PolicyV1().PodDisruptionBudgets(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
 				t.Logf("Waiting for availability of %s PodDisruptionBudget\n", operatorName)
@@ -125,9 +126,10 @@ func TestCustomResource(t *testing.T) {
 	t.Logf("PodDisruptionBudget %s available", operatorName)
 
 	// Checks to see if the NetworkPolicy is available and has the expected rules.
-	var networkPolicyFound bool
-	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		if _, err := k8sClient.NetworkingV1().NetworkPolicies(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{}); err != nil {
+	var np *networkingv1.NetworkPolicy
+	if err := wait.PollUntilContextTimeout(ctx, retryInterval, timeout, true, func(_ context.Context) (done bool, err error) {
+		np, err = k8sClient.NetworkingV1().NetworkPolicies(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{})
+		if err != nil {
 			if apierrors.IsNotFound(err) {
 				t.Logf("Waiting for availability of %s NetworkPolicy", customResourceName)
 				return false, nil
@@ -138,13 +140,7 @@ func TestCustomResource(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	networkPolicyFound = true
 	t.Logf("NetworkPolicy %s available", customResourceName)
-
-	np, err := k8sClient.NetworkingV1().NetworkPolicies(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	if len(np.OwnerReferences) < 1 {
 		t.Fatal("NetworkPolicy has no owner references")
@@ -218,15 +214,27 @@ func TestCustomResource(t *testing.T) {
 		t.Fatalf("expected 2 DNS egress ports (TCP+UDP 5353), got %d", len(dnsEgress.Ports))
 	}
 	expectedDNSPort := intstr.FromInt32(5353)
+	var sawTCP, sawUDP bool
 	for _, p := range dnsEgress.Ports {
 		if *p.Port != expectedDNSPort {
 			t.Fatalf("expected DNS port 5353, got %v", *p.Port)
 		}
+		switch *p.Protocol {
+		case corev1.ProtocolTCP:
+			sawTCP = true
+		case corev1.ProtocolUDP:
+			sawUDP = true
+		default:
+			t.Fatalf("unexpected DNS egress protocol %v", *p.Protocol)
+		}
+	}
+	if !sawTCP || !sawUDP {
+		t.Fatalf("DNS egress should have both TCP and UDP, got TCP=%t UDP=%t", sawTCP, sawUDP)
 	}
 	t.Log("NetworkPolicy ingress and egress rules validated")
 
 	var policyEngineURI string
-	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, retryInterval, timeout, true, func(_ context.Context) (done bool, err error) {
 		result := &updateservicev1.UpdateService{}
 		err = updateServiceClient.Get().
 			Resource(resource).
@@ -258,7 +266,7 @@ func TestCustomResource(t *testing.T) {
 		t.Fatal(err)
 	}
 	req.Header.Set("Accept", "application/json")
-	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, retryInterval, timeout, true, func(_ context.Context) (done bool, err error) {
 		if resp, err := httpClient.Do(req); err != nil {
 			t.Fatal(err)
 		} else if resp.StatusCode > http.StatusOK {
@@ -270,16 +278,13 @@ func TestCustomResource(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if networkPolicyFound {
-		t.Log("Route reachable with NetworkPolicy enforced — policy does not break real traffic")
-	}
 
 	if err := deleteCR(ctx); err != nil {
 		t.Log(err)
 	}
 
 	// Verify NetworkPolicy is garbage-collected after CR deletion via owner references.
-	if err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+	if err := wait.PollUntilContextTimeout(ctx, retryInterval, timeout, true, func(_ context.Context) (done bool, err error) {
 		_, err = k8sClient.NetworkingV1().NetworkPolicies(operatorNamespace).Get(ctx, customResourceName, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
Validate that deploying an UpdateService CR produces a NetworkPolicy with correct owner references, ingress rules (router to policy-engine), and egress rules (registry port 443, DNS to openshift-dns on 5353). Also verify the policy is garbage-collected on CR deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added table-driven unit tests covering multiple registry-port scenarios and detailed network-policy assertions.
  * Enhanced end-to-end tests to wait for network-policy creation, validate ingress/egress rules (including registry and DNS ports/protocols and namespace/pod selectors), and confirm cleanup after resource deletion.
  * Improved test robustness by clearing proxy environment variables and strengthening polling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->