### PR TITLE
OCPBUGS-51196: fix(rbac): add Prometheus permissions for metrics scraping

### DIFF
--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -146,6 +146,15 @@ spec:
           - list
           - watch
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes

--- a/bundle/manifests/update-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/update-service-operator.clusterserviceversion.yaml
@@ -270,6 +270,19 @@ spec:
           - update
           - watch
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - route.openshift.io
           resources:
           - routes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -144,6 +144,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -146,8 +146,8 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - roles
   - rolebindings
+  - roles
   verbs:
   - create
   - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/controllers/names.go
+++ b/controllers/names.go
@@ -26,6 +26,10 @@ const (
 	namePullSecret = "pull-secret"
 	// ClusterCAMountDir is the mount path for the dir containing cluster CA
 	ClusterCAMountDir = "/etc/pki/ca-trust/extracted/cluster-ca/"
+	// OpenshiftMonitoringNamespace is the namespace where Prometheus runs
+	OpenshiftMonitoringNamespace = "openshift-monitoring"
+	// NamePrometheusServiceAccount is the Prometheus service account name
+	NamePrometheusServiceAccount = "prometheus-k8s"
 )
 
 func nameDeployment(instance *cv1.UpdateService) string {
@@ -66,6 +70,14 @@ func nameAdditionalTrustedCA(instance *cv1.UpdateService) string {
 
 func namePullSecretCopy(instance *cv1.UpdateService) string {
 	return instance.Name + "-" + namePullSecret
+}
+
+func namePrometheusRole(instance *cv1.UpdateService) string {
+	return instance.Name + "-prometheus-k8s"
+}
+
+func namePrometheusRoleBinding(instance *cv1.UpdateService) string {
+	return instance.Name + "-prometheus-k8s"
 }
 
 // When running a single replica, allow 0 available so we don't block node

--- a/controllers/new.go
+++ b/controllers/new.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -94,6 +95,8 @@ type kubeResources struct {
 	policyEngineRoute        *routev1.Route
 	policyEngineOldRoute     *routev1.Route
 	networkPolicy            *networkingv1.NetworkPolicy
+	prometheusRole           *rbacv1.Role
+	prometheusRoleBinding    *rbacv1.RoleBinding
 	trustedCAConfig          *corev1.ConfigMap
 	trustedClusterCAConfig   *corev1.ConfigMap
 	pullSecret               *corev1.Secret
@@ -138,6 +141,8 @@ func newKubeResources(instance *cv1.UpdateService, image string, pullSecret *cor
 	k.policyEngineRoute = k.newPolicyEngineRoute(instance)
 	k.policyEngineOldRoute = k.oldPolicyEngineRoute(instance)
 	k.networkPolicy = k.newNetworkPolicy(instance)
+	k.prometheusRole = k.newPrometheusRole(instance)
+	k.prometheusRoleBinding = k.newPrometheusRoleBinding(instance)
 	return &k, nil
 }
 
@@ -511,6 +516,49 @@ func (k *kubeResources) newNetworkPolicy(instance *cv1.UpdateService) *networkin
 func corev1ProtocolPtr(proto corev1.Protocol) *corev1.Protocol { return &proto }
 
 func intOrStringPtr(intOrString intstr.IntOrString) *intstr.IntOrString { return &intOrString }
+
+func (k *kubeResources) newPrometheusRole(instance *cv1.UpdateService) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namePrometheusRole(instance),
+			Namespace: instance.Namespace,
+			Labels: map[string]string{
+				"app": instance.Name,
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services", "endpoints", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+}
+
+func (k *kubeResources) newPrometheusRoleBinding(instance *cv1.UpdateService) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      namePrometheusRoleBinding(instance),
+			Namespace: instance.Namespace,
+			Labels: map[string]string{
+				"app": instance.Name,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     namePrometheusRole(instance),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      NamePrometheusServiceAccount,
+				Namespace: OpenshiftMonitoringNamespace,
+			},
+		},
+	}
+}
 
 func (k *kubeResources) newEnvConfig(instance *cv1.UpdateService) *corev1.ConfigMap {
 	return &corev1.ConfigMap{

--- a/controllers/new_test.go
+++ b/controllers/new_test.go
@@ -44,6 +44,8 @@ func Test_newKubeResources(t *testing.T) {
 		"graph_builder_service":    actual.graphBuilderService,
 		"network_policy":           actual.networkPolicy,
 		"pod_disruption_budget":    actual.podDisruptionBudget,
+		"prometheus_role":          actual.prometheusRole,
+		"prometheus_role_binding":  actual.prometheusRoleBinding,
 		"policy_engine_old_route":  actual.policyEngineRoute,
 		"policy_engine_route":      actual.policyEngineRoute,
 		"policy_engine_service":    actual.policyEngineService,

--- a/controllers/testdata/resources/zz_fixture_Test_newKubeResources_prometheus_role.yaml
+++ b/controllers/testdata/resources/zz_fixture_Test_newKubeResources_prometheus_role.yaml
@@ -1,0 +1,17 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    app: sample
+  name: sample-prometheus-k8s
+  namespace: sample-ns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/testdata/resources/zz_fixture_Test_newKubeResources_prometheus_role_binding.yaml
+++ b/controllers/testdata/resources/zz_fixture_Test_newKubeResources_prometheus_role_binding.yaml
@@ -1,0 +1,14 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    app: sample
+  name: sample-prometheus-k8s
+  namespace: sample-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sample-prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -15,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,6 +70,7 @@ type UpdateServiceReconciler struct {
 // +kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=create;delete;get;list;patch;update;watch,namespace=openshift-update-service
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=create;get;list;patch;update;watch,namespace=openshift-update-service
 // +kubebuilder:rbac:groups=updateservice.operator.openshift.io,resources=*,verbs=create;delete;get;list;patch;update;watch,namespace=openshift-update-service
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;delete;get;list;patch;update;watch,namespace=openshift-update-service
 
 func (r *UpdateServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	/*    **Reconcile Pattern**
@@ -169,6 +171,8 @@ func (r *UpdateServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.ensurePodDisruptionBudget,
 		r.ensurePolicyEngineRoute,
 		r.ensureNetworkPolicy,
+		r.ensurePrometheusRole,
+		r.ensurePrometheusRoleBinding,
 	} {
 		err = f(ctx, reqLogger, instanceCopy, resources)
 		if err != nil {
@@ -861,6 +865,85 @@ func (r *UpdateServiceReconciler) ensureNetworkPolicy(ctx context.Context, reqLo
 	return nil
 }
 
+func (r *UpdateServiceReconciler) ensurePrometheusRole(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
+	role := resources.prometheusRole
+	if err := controllerutil.SetControllerReference(instance, role, r.Scheme); err != nil {
+		return err
+	}
+
+	found := &rbacv1.Role{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, found)
+	if err != nil && apiErrors.IsNotFound(err) {
+		reqLogger.Info("Creating Prometheus Role", "Namespace", role.Namespace, "Name", role.Name)
+		if err = r.Client.Create(ctx, role); err != nil {
+			handleErr(reqLogger, &instance.Status, "CreatePrometheusRoleFailed", err)
+		}
+		return err
+	} else if err != nil {
+		handleErr(reqLogger, &instance.Status, "GetPrometheusRoleFailed", err)
+		return err
+	}
+
+	if !reflect.DeepEqual(found.Rules, role.Rules) {
+		reqLogger.Info("Updating Prometheus Role", "Namespace", role.Namespace, "Name", role.Name)
+		updated := found.DeepCopy()
+		updated.Rules = role.Rules
+		err = r.Client.Update(ctx, updated)
+		if err != nil {
+			handleErr(reqLogger, &instance.Status, "UpdatePrometheusRoleFailed", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *UpdateServiceReconciler) ensurePrometheusRoleBinding(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
+	rb := resources.prometheusRoleBinding
+	if err := controllerutil.SetControllerReference(instance, rb, r.Scheme); err != nil {
+		return err
+	}
+
+	found := &rbacv1.RoleBinding{}
+	err := r.Client.Get(ctx, types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace}, found)
+	if err != nil && apiErrors.IsNotFound(err) {
+		reqLogger.Info("Creating Prometheus RoleBinding", "Namespace", rb.Namespace, "Name", rb.Name)
+		if err = r.Client.Create(ctx, rb); err != nil {
+			handleErr(reqLogger, &instance.Status, "CreatePrometheusRoleBindingFailed", err)
+		}
+		return err
+	} else if err != nil {
+		handleErr(reqLogger, &instance.Status, "GetPrometheusRoleBindingFailed", err)
+		return err
+	}
+
+	// RoleRef is immutable; if it changed, delete and recreate
+	if !reflect.DeepEqual(found.RoleRef, rb.RoleRef) {
+		reqLogger.Info("Recreating Prometheus RoleBinding (RoleRef changed)", "Namespace", rb.Namespace, "Name", rb.Name)
+		if err = r.Client.Delete(ctx, found); err != nil {
+			handleErr(reqLogger, &instance.Status, "DeletePrometheusRoleBindingFailed", err)
+			return err
+		}
+		if err = r.Client.Create(ctx, rb); err != nil {
+			handleErr(reqLogger, &instance.Status, "CreatePrometheusRoleBindingFailed", err)
+		}
+		return err
+	}
+
+	if !reflect.DeepEqual(found.Subjects, rb.Subjects) {
+		reqLogger.Info("Updating Prometheus RoleBinding", "Namespace", rb.Namespace, "Name", rb.Name)
+		updated := found.DeepCopy()
+		updated.Subjects = rb.Subjects
+		err = r.Client.Update(ctx, updated)
+		if err != nil {
+			handleErr(reqLogger, &instance.Status, "UpdatePrometheusRoleBindingFailed", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *UpdateServiceReconciler) SetupWithManager(mgr ctrl.Manager, namespace string) error {
 	mapped := &mapper{client: mgr.GetClient(), namespace: namespace}
@@ -873,6 +956,8 @@ func (r *UpdateServiceReconciler) SetupWithManager(mgr ctrl.Manager, namespace s
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&routev1.Route{}).
 		Owns(&networkingv1.NetworkPolicy{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
 		Owns(&corev1.Pod{}).
 		Watches(
 			&apicfgv1.Image{},

--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -868,10 +868,12 @@ func (r *UpdateServiceReconciler) ensureNetworkPolicy(ctx context.Context, reqLo
 
 func (r *UpdateServiceReconciler) ensurePrometheusRole(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
 	role := resources.prometheusRole
+	// Set UpdateService instance as the owner and controller
 	if err := controllerutil.SetControllerReference(instance, role, r.Scheme); err != nil {
 		return err
 	}
 
+	// Check if it already exists
 	found := &rbacv1.Role{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: role.Name, Namespace: role.Namespace}, found)
 	if err != nil && apiErrors.IsNotFound(err) {
@@ -885,6 +887,7 @@ func (r *UpdateServiceReconciler) ensurePrometheusRole(ctx context.Context, reqL
 		return err
 	}
 
+	// found existing resource; let's compare and update if needed
 	if !reflect.DeepEqual(found.Rules, role.Rules) {
 		reqLogger.Info("Updating Prometheus Role", "Namespace", role.Namespace, "Name", role.Name)
 		updated := found.DeepCopy()
@@ -892,7 +895,6 @@ func (r *UpdateServiceReconciler) ensurePrometheusRole(ctx context.Context, reqL
 		err = r.Client.Update(ctx, updated)
 		if err != nil {
 			handleErr(reqLogger, &instance.Status, "UpdatePrometheusRoleFailed", err)
-			return err
 		}
 	}
 
@@ -901,10 +903,12 @@ func (r *UpdateServiceReconciler) ensurePrometheusRole(ctx context.Context, reqL
 
 func (r *UpdateServiceReconciler) ensurePrometheusRoleBinding(ctx context.Context, reqLogger logr.Logger, instance *cv1.UpdateService, resources *kubeResources) error {
 	rb := resources.prometheusRoleBinding
+	// Set UpdateService instance as the owner and controller
 	if err := controllerutil.SetControllerReference(instance, rb, r.Scheme); err != nil {
 		return err
 	}
 
+	// Check if it already exists
 	found := &rbacv1.RoleBinding{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace}, found)
 	if err != nil && apiErrors.IsNotFound(err) {
@@ -931,6 +935,7 @@ func (r *UpdateServiceReconciler) ensurePrometheusRoleBinding(ctx context.Contex
 		return err
 	}
 
+	// found existing resource; let's compare and update if needed
 	if !reflect.DeepEqual(found.Subjects, rb.Subjects) {
 		reqLogger.Info("Updating Prometheus RoleBinding", "Namespace", rb.Namespace, "Name", rb.Name)
 		updated := found.DeepCopy()
@@ -938,7 +943,6 @@ func (r *UpdateServiceReconciler) ensurePrometheusRoleBinding(ctx context.Contex
 		err = r.Client.Update(ctx, updated)
 		if err != nil {
 			handleErr(reqLogger, &instance.Status, "UpdatePrometheusRoleBindingFailed", err)
-			return err
 		}
 	}
 

--- a/controllers/updateservice_controller.go
+++ b/controllers/updateservice_controller.go
@@ -62,6 +62,7 @@ type UpdateServiceReconciler struct {
 // +kubebuilder:rbac:groups=config.openshift.io,resources=images,verbs=get;list;watch
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=updateservice.operator.openshift.io,resources=*,verbs=get;list;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods;services;services/finalizers;endpoints;persistentvolumeclaims;events;configmaps;secrets,verbs=create;delete;get;list;patch;update;watch,namespace=openshift-update-service
 // +kubebuilder:rbac:groups="apps",resourceNames=updateservice-operator,resources=deployments/finalizers,verbs=update,namespace=openshift-update-service
 // +kubebuilder:rbac:groups="apps",resources=deployments;daemonsets;replicasets;statefulsets,verbs=create;delete;get;list;patch;update;watch,namespace=openshift-update-service


### PR DESCRIPTION
When the `openshift.io/cluster-monitoring=true` label is added to the `openshift-update-service` namespace, Prometheus fails to scrape metrics because the `prometheus-k8s` service account lacks permissions to list pods, services, and endpoints. This adds a managed Role and RoleBinding to grant the necessary read access.

The operator's reconcile loop now ensures both resources exist, updates them if they drift, and handles RoleBinding.RoleRef immutability by deleting and recreating when needed. Owner references ensure cleanup on UpdateService CR deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus monitoring support with RBAC. The operator now automatically creates and reconciles the required permissions and role bindings for Prometheus metrics collection in the relevant namespaces.
* **Bug Fixes**
  * Improved RBAC reconciliation to keep Prometheus-related Roles and RoleBindings in sync, updating them when permissions drift or when bindings need to be re-created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->