### PR TITLE
OTA-1975: add products-data container and service to service products.json if present in graph-data image

### DIFF
--- a/controllers/new.go
+++ b/controllers/new.go
@@ -191,6 +191,12 @@ func (k *kubeResources) newGraphBuilderService(instance *cv1.UpdateService) *cor
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
+					Name:       "products-data",
+					Port:       8090,
+					TargetPort: intstr.FromInt32(8090),
+					Protocol:   corev1.ProtocolTCP,
+				},
+				{
 					Name:       "status-gb",
 					Port:       9080,
 					TargetPort: intstr.FromInt32(9080),
@@ -809,6 +815,11 @@ func (k *kubeResources) newGraphBuilderContainer(instance *cv1.UpdateService, im
 			{
 				Name:          "graph-builder",
 				ContainerPort: 8080,
+				Protocol:      corev1.ProtocolTCP,
+			},
+			{
+				Name:          "products-data",
+				ContainerPort: 8090,
 				Protocol:      corev1.ProtocolTCP,
 			},
 			{

--- a/controllers/testdata/resources/zz_fixture_Test_newKubeResources_deployment.yaml
+++ b/controllers/testdata/resources/zz_fixture_Test_newKubeResources_deployment.yaml
@@ -54,6 +54,9 @@ spec:
         - containerPort: 8080
           name: graph-builder
           protocol: TCP
+        - containerPort: 8090
+          name: products-data
+          protocol: TCP
         - containerPort: 9080
           name: status-gb
           protocol: TCP

--- a/controllers/testdata/resources/zz_fixture_Test_newKubeResources_graph_builder_service.yaml
+++ b/controllers/testdata/resources/zz_fixture_Test_newKubeResources_graph_builder_service.yaml
@@ -16,6 +16,10 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: 8080
+  - name: products-data
+    port: 8090
+    protocol: TCP
+    targetPort: 8090
   - name: status-gb
     port: 9080
     protocol: TCP

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -4,4 +4,9 @@ RUN curl -L -o cincinnati-graph-data.tar.gz https://api.openshift.com/api/upgrad
 
 RUN mkdir -p /var/lib/cincinnati-graph-data && tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati-graph-data/ --no-overwrite-dir --no-same-owner
 
+RUN [ -f /var/lib/cincinnati-graph-data/products.json ] || \
+      curl -L -o /var/lib/cincinnati-graph-data/products.json https://access.redhat.com/product-life-cycles/api/v2/products || \
+      echo "{}" > /var/lib/cincinnati-graph-data/products.json
+
+
 CMD ["/bin/bash", "-c" ,"exec cp -rpv /var/lib/cincinnati-graph-data/* /var/lib/cincinnati/graph-data"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional `products-data` TCP port on **8090** for the graph-building service (and matching container port exposure).
* **Development**
  * Development Docker images now ensure `products.json` exists by downloading it when missing, or initializing an empty file if the download fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->