### PR TITLE
chore(deps): bump github.com/golang-jwt/jwt/v4 to v4.5.2 (CVE-2025-30204)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,9 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/vendor/github.com/golang-jwt/jwt/v4/README.md
+++ b/vendor/github.com/golang-jwt/jwt/v4/README.md
@@ -36,19 +36,41 @@ The part in the middle is the interesting bit.  It's called the Claims and conta
 
 This library supports the parsing and verification as well as the generation and signing of JWTs.  Current supported signing algorithms are HMAC SHA, RSA, RSA-PSS, and ECDSA, though hooks are present for adding your own.
 
+## Installation Guidelines
+
+1. To install the jwt package, you first need to have [Go](https://go.dev/doc/install) installed, then you can use the command below to add `jwt-go` as a dependency in your Go program.
+
+```sh
+go get -u github.com/golang-jwt/jwt/v4
+```
+
+2. Import it in your code:
+
+```go
+import "github.com/golang-jwt/jwt/v4"
+```
+
 ## Examples
 
-See [the project documentation](https://pkg.go.dev/github.com/golang-jwt/jwt) for examples of usage:
+See [the project documentation](https://pkg.go.dev/github.com/golang-jwt/jwt/v4) for examples of usage:
 
-* [Simple example of parsing and validating a token](https://pkg.go.dev/github.com/golang-jwt/jwt#example-Parse-Hmac)
-* [Simple example of building and signing a token](https://pkg.go.dev/github.com/golang-jwt/jwt#example-New-Hmac)
-* [Directory of Examples](https://pkg.go.dev/github.com/golang-jwt/jwt#pkg-examples)
+* [Simple example of parsing and validating a token](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#example-Parse-Hmac)
+* [Simple example of building and signing a token](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#example-New-Hmac)
+* [Directory of Examples](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#pkg-examples)
 
 ## Extensions
 
-This library publishes all the necessary components for adding your own signing methods.  Simply implement the `SigningMethod` interface and register a factory method using `RegisterSigningMethod`.  
+This library publishes all the necessary components for adding your own signing methods or key functions.  Simply implement the `SigningMethod` interface and register a factory method using `RegisterSigningMethod` or provide a `jwt.Keyfunc`.
 
-Here's an example of an extension that integrates with multiple Google Cloud Platform signing tools (AppEngine, IAM API, Cloud KMS): https://github.com/someone1/gcp-jwt-go
+A common use case would be integrating with different 3rd party signature providers, like key management services from various cloud providers or Hardware Security Modules (HSMs) or to implement additional standards.
+
+| Extension | Purpose                                                                                                  | Repo                                       |
+| --------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| GCP       | Integrates with multiple Google Cloud Platform signing tools (AppEngine, IAM API, Cloud KMS)             | https://github.com/someone1/gcp-jwt-go     |
+| AWS       | Integrates with AWS Key Management Service, KMS                                                          | https://github.com/matelang/jwt-go-aws-kms |
+| JWKS      | Provides support for JWKS ([RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517)) as a `jwt.Keyfunc` | https://github.com/MicahParks/keyfunc       |
+
+*Disclaimer*: Unless otherwise specified, these integrations are maintained by third parties and should not be considered as a primary offer by any of the mentioned cloud providers
 
 ## Compliance
 
@@ -74,7 +96,7 @@ A token is simply a JSON object that is signed by its author. this tells you exa
 * The author of the token was in the possession of the signing secret
 * The data has not been modified since it was signed
 
-It's important to know that JWT does not provide encryption, which means anyone who has access to the token can read its contents. If you need to protect (encrypt) the data, there is a companion spec, `JWE`, that provides this functionality. JWE is currently outside the scope of this library.
+It's important to know that JWT does not provide encryption, which means anyone who has access to the token can read its contents. If you need to protect (encrypt) the data, there is a companion spec, `JWE`, that provides this functionality. The companion project https://github.com/golang-jwt/jwe aims at a (very) experimental implementation of the JWE standard.
 
 ### Choosing a Signing Method
 
@@ -88,10 +110,10 @@ Asymmetric signing methods, such as RSA, use different keys for signing and veri
 
 Each signing method expects a different object type for its signing keys. See the package documentation for details. Here are the most common ones:
 
-* The [HMAC signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodHMAC) (`HS256`,`HS384`,`HS512`) expect `[]byte` values for signing and validation
-* The [RSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodRSA) (`RS256`,`RS384`,`RS512`) expect `*rsa.PrivateKey` for signing and `*rsa.PublicKey` for validation
-* The [ECDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodECDSA) (`ES256`,`ES384`,`ES512`) expect `*ecdsa.PrivateKey` for signing and `*ecdsa.PublicKey` for validation
-* The [EdDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodEd25519) (`Ed25519`) expect `ed25519.PrivateKey` for signing and `ed25519.PublicKey` for validation
+* The [HMAC signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodHMAC) (`HS256`,`HS384`,`HS512`) expect `[]byte` values for signing and validation
+* The [RSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodRSA) (`RS256`,`RS384`,`RS512`) expect `*rsa.PrivateKey` for signing and `*rsa.PublicKey` for validation
+* The [ECDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodECDSA) (`ES256`,`ES384`,`ES512`) expect `*ecdsa.PrivateKey` for signing and `*ecdsa.PublicKey` for validation
+* The [EdDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodEd25519) (`Ed25519`) expect `ed25519.PrivateKey` for signing and `ed25519.PublicKey` for validation
 
 ### JWT and OAuth
 
@@ -109,6 +131,8 @@ This library uses descriptive error messages whenever possible. If you are not g
 
 ## More
 
-Documentation can be found [on pkg.go.dev](https://pkg.go.dev/github.com/golang-jwt/jwt).
+Documentation can be found [on pkg.go.dev](https://pkg.go.dev/github.com/golang-jwt/jwt/v4).
 
 The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration. You'll also find several implementation examples in the documentation.
+
+[golang-jwt](https://github.com/orgs/golang-jwt) incorporates a modified version of the JWT logo, which is distributed under the terms of the [MIT License](https://github.com/jsonwebtoken/jsonwebtoken.github.io/blob/master/LICENSE.txt).

--- a/vendor/github.com/golang-jwt/jwt/v4/SECURITY.md
+++ b/vendor/github.com/golang-jwt/jwt/v4/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+As of February 2022 (and until this document is updated), the latest version `v4` is supported.
+
+## Reporting a Vulnerability
+
+If you think you found a vulnerability, and even if you are not sure, please report it to jwt-go-security@googlegroups.com or one of the other [golang-jwt maintainers](https://github.com/orgs/golang-jwt/people). Please try be explicit, describe steps to reproduce the security issue with code example(s).
+
+You will receive a response within a timely manner. If the issue is confirmed, we will do our best to release a patch as soon as possible given the complexity of the problem.
+
+## Public Discussions
+
+Please avoid publicly discussing a potential security vulnerability.
+
+Let's take this offline and find a solution first, this limits the potential impact as much as possible.
+
+We appreciate your help!

--- a/vendor/github.com/golang-jwt/jwt/v4/claims.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/claims.go
@@ -56,17 +56,17 @@ func (c RegisteredClaims) Valid() error {
 	// default value in Go, let's not fail the verification for them.
 	if !c.VerifyExpiresAt(now, false) {
 		delta := now.Sub(c.ExpiresAt.Time)
-		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
+		vErr.Inner = fmt.Errorf("%s by %s", ErrTokenExpired, delta)
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if !c.VerifyIssuedAt(now, false) {
-		vErr.Inner = fmt.Errorf("token used before issued")
+		vErr.Inner = ErrTokenUsedBeforeIssued
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if !c.VerifyNotBefore(now, false) {
-		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Inner = ErrTokenNotValidYet
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 
@@ -149,17 +149,17 @@ func (c StandardClaims) Valid() error {
 	// default value in Go, let's not fail the verification for them.
 	if !c.VerifyExpiresAt(now, false) {
 		delta := time.Unix(now, 0).Sub(time.Unix(c.ExpiresAt, 0))
-		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
+		vErr.Inner = fmt.Errorf("%s by %s", ErrTokenExpired, delta)
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if !c.VerifyIssuedAt(now, false) {
-		vErr.Inner = fmt.Errorf("token used before issued")
+		vErr.Inner = ErrTokenUsedBeforeIssued
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if !c.VerifyNotBefore(now, false) {
-		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Inner = ErrTokenNotValidYet
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 
@@ -265,9 +265,5 @@ func verifyIss(iss string, cmp string, required bool) bool {
 	if iss == "" {
 		return !required
 	}
-	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
-		return true
-	} else {
-		return false
-	}
+	return subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0
 }

--- a/vendor/github.com/golang-jwt/jwt/v4/errors.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/errors.go
@@ -9,6 +9,18 @@ var (
 	ErrInvalidKey      = errors.New("key is invalid")
 	ErrInvalidKeyType  = errors.New("key is of invalid type")
 	ErrHashUnavailable = errors.New("the requested hash function is unavailable")
+
+	ErrTokenMalformed        = errors.New("token is malformed")
+	ErrTokenUnverifiable     = errors.New("token is unverifiable")
+	ErrTokenSignatureInvalid = errors.New("token signature is invalid")
+
+	ErrTokenInvalidAudience  = errors.New("token has invalid audience")
+	ErrTokenExpired          = errors.New("token is expired")
+	ErrTokenUsedBeforeIssued = errors.New("token used before issued")
+	ErrTokenInvalidIssuer    = errors.New("token has invalid issuer")
+	ErrTokenNotValidYet      = errors.New("token is not valid yet")
+	ErrTokenInvalidId        = errors.New("token has invalid id")
+	ErrTokenInvalidClaims    = errors.New("token has invalid claims")
 )
 
 // The errors that might occur when parsing and validating a token
@@ -61,4 +73,40 @@ func (e *ValidationError) Unwrap() error {
 // No errors
 func (e *ValidationError) valid() bool {
 	return e.Errors == 0
+}
+
+// Is checks if this ValidationError is of the supplied error. We are first checking for the exact error message
+// by comparing the inner error message. If that fails, we compare using the error flags. This way we can use
+// custom error messages (mainly for backwards compatability) and still leverage errors.Is using the global error variables.
+func (e *ValidationError) Is(err error) bool {
+	// Check, if our inner error is a direct match
+	if errors.Is(errors.Unwrap(e), err) {
+		return true
+	}
+
+	// Otherwise, we need to match using our error flags
+	switch err {
+	case ErrTokenMalformed:
+		return e.Errors&ValidationErrorMalformed != 0
+	case ErrTokenUnverifiable:
+		return e.Errors&ValidationErrorUnverifiable != 0
+	case ErrTokenSignatureInvalid:
+		return e.Errors&ValidationErrorSignatureInvalid != 0
+	case ErrTokenInvalidAudience:
+		return e.Errors&ValidationErrorAudience != 0
+	case ErrTokenExpired:
+		return e.Errors&ValidationErrorExpired != 0
+	case ErrTokenUsedBeforeIssued:
+		return e.Errors&ValidationErrorIssuedAt != 0
+	case ErrTokenInvalidIssuer:
+		return e.Errors&ValidationErrorIssuer != 0
+	case ErrTokenNotValidYet:
+		return e.Errors&ValidationErrorNotValidYet != 0
+	case ErrTokenInvalidId:
+		return e.Errors&ValidationErrorId != 0
+	case ErrTokenInvalidClaims:
+		return e.Errors&ValidationErrorClaimsInvalid != 0
+	}
+
+	return false
 }

--- a/vendor/github.com/golang-jwt/jwt/v4/map_claims.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/map_claims.go
@@ -126,16 +126,19 @@ func (m MapClaims) Valid() error {
 	now := TimeFunc().Unix()
 
 	if !m.VerifyExpiresAt(now, false) {
+		// TODO(oxisto): this should be replaced with ErrTokenExpired
 		vErr.Inner = errors.New("Token is expired")
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if !m.VerifyIssuedAt(now, false) {
+		// TODO(oxisto): this should be replaced with ErrTokenUsedBeforeIssued
 		vErr.Inner = errors.New("Token used before issued")
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if !m.VerifyNotBefore(now, false) {
+		// TODO(oxisto): this should be replaced with ErrTokenNotValidYet
 		vErr.Inner = errors.New("Token is not valid yet")
 		vErr.Errors |= ValidationErrorNotValidYet
 	}

--- a/vendor/github.com/golang-jwt/jwt/v4/parser.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/parser.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const tokenDelimiter = "."
+
 type Parser struct {
 	// If populated, only these methods will be considered valid.
 	//
@@ -36,12 +38,21 @@ func NewParser(options ...ParserOption) *Parser {
 	return p
 }
 
-// Parse parses, validates, verifies the signature and returns the parsed token.
-// keyFunc will receive the parsed token and should return the key for validating.
+// Parse parses, validates, verifies the signature and returns the parsed token. keyFunc will
+// receive the parsed token and should return the key for validating.
 func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
 }
 
+// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object
+// implementing the Claims interface. This provides default values which can be overridden and
+// allows a caller to use their own type, rather than the default MapClaims implementation of
+// Claims.
+//
+// Note: If you provide a custom claim implementation that embeds one of the standard claims (such
+// as RegisteredClaims), make sure that a) you either embed a non-pointer version of the claims or
+// b) if you are using a pointer, allocate the proper memory for it before passing in the overall
+// claims, otherwise you might run into a panic.
 func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
 	token, parts, err := p.ParseUnverified(tokenString, claims)
 	if err != nil {
@@ -78,12 +89,17 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
 	}
 
+	// Perform validation
+	token.Signature = parts[2]
+	if err := token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorSignatureInvalid}
+	}
+
 	vErr := &ValidationError{}
 
 	// Validate Claims
 	if !p.SkipClaimsValidation {
 		if err := token.Claims.Valid(); err != nil {
-
 			// If the Claims Valid returned an error, check if it is a validation error,
 			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
 			if e, ok := err.(*ValidationError); !ok {
@@ -91,22 +107,14 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 			} else {
 				vErr = e
 			}
+			return token, vErr
 		}
 	}
 
-	// Perform validation
-	token.Signature = parts[2]
-	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
-		vErr.Inner = err
-		vErr.Errors |= ValidationErrorSignatureInvalid
-	}
+	// No errors so far, token is valid.
+	token.Valid = true
 
-	if vErr.valid() {
-		token.Valid = true
-		return token, nil
-	}
-
-	return token, vErr
+	return token, nil
 }
 
 // ParseUnverified parses the token but doesn't validate the signature.
@@ -116,9 +124,10 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 // It's only ever useful in cases where you know the signature is valid (because it has
 // been checked previously in the stack) and you want to extract values from it.
 func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Token, parts []string, err error) {
-	parts = strings.Split(tokenString, ".")
-	if len(parts) != 3 {
-		return nil, parts, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
+	var ok bool
+	parts, ok = splitToken(tokenString)
+	if !ok {
+		return nil, nil, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
 	}
 
 	token = &Token{Raw: tokenString}
@@ -167,4 +176,31 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	}
 
 	return token, parts, nil
+}
+
+// splitToken splits a token string into three parts: header, claims, and signature. It will only
+// return true if the token contains exactly two delimiters and three parts. In all other cases, it
+// will return nil parts and false.
+func splitToken(token string) ([]string, bool) {
+	parts := make([]string, 3)
+	header, remain, ok := strings.Cut(token, tokenDelimiter)
+	if !ok {
+		return nil, false
+	}
+	parts[0] = header
+	claims, remain, ok := strings.Cut(remain, tokenDelimiter)
+	if !ok {
+		return nil, false
+	}
+	parts[1] = claims
+	// One more cut to ensure the signature is the last part of the token and there are no more
+	// delimiters. This avoids an issue where malicious input could contain additional delimiters
+	// causing unecessary overhead parsing tokens.
+	signature, _, unexpected := strings.Cut(remain, tokenDelimiter)
+	if unexpected {
+		return nil, false
+	}
+	parts[2] = signature
+
+	return parts, true
 }

--- a/vendor/github.com/golang-jwt/jwt/v4/parser_option.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/parser_option.go
@@ -1,6 +1,6 @@
 package jwt
 
-// ParserOption is used to implement functional-style options that modify the behaviour of the parser. To add
+// ParserOption is used to implement functional-style options that modify the behavior of the parser. To add
 // new options, just create a function (ideally beginning with With or Without) that returns an anonymous function that
 // takes a *Parser type as input and manipulates its configuration accordingly.
 type ParserOption func(*Parser)
@@ -13,7 +13,7 @@ func WithValidMethods(methods []string) ParserOption {
 	}
 }
 
-// WithJSONNumber is an option to configure the underyling JSON parser with UseNumber
+// WithJSONNumber is an option to configure the underlying JSON parser with UseNumber
 func WithJSONNumber() ParserOption {
 	return func(p *Parser) {
 		p.UseJSONNumber = true

--- a/vendor/github.com/golang-jwt/jwt/v4/rsa_pss.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/rsa_pss.go
@@ -1,3 +1,4 @@
+//go:build go1.4
 // +build go1.4
 
 package jwt

--- a/vendor/github.com/golang-jwt/jwt/v4/types.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/types.go
@@ -49,9 +49,27 @@ func newNumericDateFromSeconds(f float64) *NumericDate {
 // MarshalJSON is an implementation of the json.RawMessage interface and serializes the UNIX epoch
 // represented in NumericDate to a byte array, using the precision specified in TimePrecision.
 func (date NumericDate) MarshalJSON() (b []byte, err error) {
-	f := float64(date.Truncate(TimePrecision).UnixNano()) / float64(time.Second)
+	var prec int
+	if TimePrecision < time.Second {
+		prec = int(math.Log10(float64(time.Second) / float64(TimePrecision)))
+	}
+	truncatedDate := date.Truncate(TimePrecision)
 
-	return []byte(strconv.FormatFloat(f, 'f', -1, 64)), nil
+	// For very large timestamps, UnixNano would overflow an int64, but this
+	// function requires nanosecond level precision, so we have to use the
+	// following technique to get round the issue:
+	// 1. Take the normal unix timestamp to form the whole number part of the
+	//    output,
+	// 2. Take the result of the Nanosecond function, which retuns the offset
+	//    within the second of the particular unix time instance, to form the
+	//    decimal part of the output
+	// 3. Concatenate them to produce the final result
+	seconds := strconv.FormatInt(truncatedDate.Unix(), 10)
+	nanosecondsOffset := strconv.FormatFloat(float64(truncatedDate.Nanosecond())/float64(time.Second), 'f', prec, 64)
+
+	output := append([]byte(seconds), []byte(nanosecondsOffset)[1:]...)
+
+	return output, nil
 }
 
 // UnmarshalJSON is an implementation of the json.RawMessage interface and deserializses a

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -67,8 +67,8 @@ github.com/go-openapi/swag
 ## explicit; go 1.15
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
-# github.com/golang-jwt/jwt/v4 v4.2.0
-## explicit; go 1.15
+# github.com/golang-jwt/jwt/v4 v4.5.2
+## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
 # github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 ## explicit


### PR DESCRIPTION
Addresses CVE-2025-30204 (GHSA-mh63-6h87-95cp / GO-2025-3553) and, as a bonus, also clears GO-2024-3250 (improper error handling in `ParseWithClaims`, fixed in v4.5.1) since v4.5.2 supersedes it.

`golang-jwt/jwt/v4` is an indirect/transitive dependency of this repo. `Parser.ParseUnverified` (the CVE-2025-30204 vulnerable function, which uses `strings.Split` on untrusted input) is never called by cincinnati-operator's own code.

## Proof: govulncheck (before vs. after)

**Before (v4.2.0):**
```
Vulnerability #3: GO-2025-3553
    Excessive memory allocation during header parsing in github.com/golang-jwt/jwt
  Module: github.com/golang-jwt/jwt/v4
    Found in: github.com/golang-jwt/jwt/v4@v4.2.0
    Fixed in: github.com/golang-jwt/jwt/v4@v4.5.2

Vulnerability #5: GO-2024-3250
    Improper error handling in ParseWithClaims ...
  Module: github.com/golang-jwt/jwt/v4
    Found in: github.com/golang-jwt/jwt/v4@v4.2.0
    Fixed in: github.com/golang-jwt/jwt/v4@v4.5.1

Summary: affected by 10 vulnerabilities (reachable); 6 vulnerabilities
in imported-but-not-called packages (includes both jwt CVEs above).
```

**After (v4.5.2):**
```
No mention of golang-jwt anywhere in output.
Summary: affected by 10 vulnerabilities (reachable, unchanged — jwt was
never in this bucket); 4 vulnerabilities in imported-but-not-called
packages (down from 6 — both jwt CVEs cleared).
```

This confirms both CVEs were never reachable from our code (the "affected"/reachable count is identical before and after), and the bump removes them from the dependency tree entirely.

## Proof: build / vet / tests

```
$ go build ./...
BUILD OK

$ go vet ./...
VET OK

$ go test ./controllers/... -v
... (56 test cases across TestEnsureAdditionalTrustedCA, TestEnsureDeployment,
     TestEnsureGraphBuilderService, TestEnsurePolicyEngineService,
     TestEnsurePodDisruptionBudget, TestValidateRouteName,
     TestEnsurePolicyEngineRoute, etc.)
PASS
ok  	github.com/openshift/cincinnati-operator/controllers	0.628s

$ go test ./controllers/... -cover
ok  	github.com/openshift/cincinnati-operator/controllers	0.799s	coverage: 56.0% of statements
```

This bump is pre-emptive dependency hygiene; the corresponding Jira ticket (OCPBUGS-105272) is being closed as Not-A-Bug since no reachable exploitation path exists in this component.

OCPBUGS-105272